### PR TITLE
Corrige testes e caminhos no Windows

### DIFF
--- a/CoupaTurboDownloader/process_all_pos.py
+++ b/CoupaTurboDownloader/process_all_pos.py
@@ -5,7 +5,7 @@ import time
 import argparse
 import json
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import pandas as pd
 from src.db.session_db import SessionDB
 from src.engine.crawler import CoupaCrawler
@@ -189,7 +189,7 @@ def _build_output_subdir(row: pd.Series, supplier: str, hierarchy_cols: list[str
         parts = [_clean_folder_part(row.get(col, "")) for col in hierarchy_cols]
     else:
         parts = [str(supplier).strip() or "Unknown"]
-    return os.path.join(*parts)
+    return PurePosixPath(*parts).as_posix()
 
 
 def build_output_subdir_map_from_csv(input_csv: str) -> dict[str, str]:

--- a/CoupaTurboDownloader/src/engine/crawler.py
+++ b/CoupaTurboDownloader/src/engine/crawler.py
@@ -245,10 +245,16 @@ class CoupaCrawler:
         if po_record and po_record["status"] == "SKIPPED_VERIFICATION_REQUIRED":
             return {"po": po_number, "success": False, "error": "SKIPPED_VERIFICATION_REQUIRED"}
 
-        po_dir_parent = company_code
+        po_dir_parts = [company_code]
         if po_record and po_record.get("output_subdir"):
-            po_dir_parent = po_record["output_subdir"]
-        po_dir = os.path.join(self.base_download_dir, po_dir_parent, po_number)
+            # output_subdir is stored with POSIX separators so sessions remain
+            # portable. Accept legacy backslashes while creating a native path.
+            po_dir_parts = [
+                part
+                for part in re.split(r"[\\/]+", str(po_record["output_subdir"]))
+                if part not in {"", ".", ".."}
+            ] or [company_code]
+        po_dir = os.path.join(self.base_download_dir, *po_dir_parts, po_number)
         dir_created = False
         start_time = time.time()
 

--- a/CoupaTurboDownloader/src/gui/api.py
+++ b/CoupaTurboDownloader/src/gui/api.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import threading
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Dict, Any, List, Optional
 
 import pandas as pd
@@ -1151,7 +1151,7 @@ class AppAPI:
                 if po_val and po_val.lower() != 'nan' and company_val and company_val.lower() != 'nan':
                     if has_hierarchy_data and hierarchy_cols:
                         parts = [clean_folder_part(row.get(col, '')) for col in hierarchy_cols]
-                        output_subdir = os.path.join(*parts)
+                        output_subdir = PurePosixPath(*parts).as_posix()
                     else:
                         output_subdir = company_val
 

--- a/CoupaTurboDownloader/tests/e2e/test_e2e_csv_sample_pipeline.py
+++ b/CoupaTurboDownloader/tests/e2e/test_e2e_csv_sample_pipeline.py
@@ -1,9 +1,7 @@
 import os
-from pathlib import Path
-
 import pandas as pd
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 from src.db.session_db import SessionDB
 from src.gui.api import AppAPI
@@ -12,17 +10,11 @@ from src.engine.crawler import CoupaCrawler
 
 @pytest.mark.asyncio
 async def test_e2e_pipeline_with_sample_from_input_csv(tmp_path):
-    repo_root = Path(__file__).resolve().parents[2]
-    source_csv = repo_root / "input.csv"
-    assert source_csv.exists(), "Expected sample source CSV to exist at project root"
-
-    raw_df = pd.read_csv(source_csv, sep=";", dtype=str)
-    sample_df = raw_df[["PO_NUMBER", "SUPPLIER"]].dropna().head(3).copy()
-    assert len(sample_df) == 3, "Need at least 3 valid rows in input.csv for E2E sample"
-
-    normalized_df = sample_df.rename(columns={
-        "PO_NUMBER": "PO Number",
-        "SUPPLIER": "legal entity",
+    # Keep the E2E fixture deterministic and independent from ignored local
+    # input files, which are intentionally unavailable on CI runners.
+    normalized_df = pd.DataFrame({
+        "PO Number": ["PO1001", "PO1002", "PO1003"],
+        "legal entity": ["ACME-BR", "ACME-BR", "ACME-US"],
     })
     normalized_csv = tmp_path / "sample_for_e2e.csv"
     normalized_df.to_csv(normalized_csv, index=False)

--- a/CoupaTurboDownloader/tests/test_crawler.py
+++ b/CoupaTurboDownloader/tests/test_crawler.py
@@ -175,8 +175,9 @@ async def test_process_po_uses_output_subdir_for_path(tmp_download_dir):
     await crawler.process_po(po_number="PO777", company_code="CC1")
 
     assert crawler._download_attachment.call_count == 1
-    dest_path = crawler._download_attachment.call_args.args[1]
-    assert "2026/Q12026/Yellow_Wood/PO777" in dest_path
+    dest_path = os.path.normpath(crawler._download_attachment.call_args.args[1])
+    expected_subdir = os.path.join("2026", "Q12026", "Yellow_Wood", "PO777")
+    assert expected_subdir in dest_path
     await crawler.close()
 
 


### PR DESCRIPTION
## Correções
- remove dependência de `input.csv` local nos testes
- armazena `output_subdir` em formato POSIX portável
- converte o caminho canônico para o formato nativo ao criar pastas
- torna as asserções de caminho independentes do sistema operacional

## Validação
- 91 testes aprovados localmente
- `uv lock --check` aprovado
- Python compilado sem erros

## Summary by Sourcery

Make CSV-based E2E tests and purchase order output paths portable across operating systems, including Windows.

Bug Fixes:
- Remove dependency on a local input.csv file in E2E tests so they run reliably in CI and on all machines.
- Ensure output_subdir values are stored with POSIX separators and converted safely to native paths when creating download directories.
- Make crawler destination path assertions OS-independent by using normalized paths.

Enhancements:
- Generate a fixed in-memory CSV sample for the E2E pipeline test to keep it deterministic and self-contained.
- Use PurePosixPath when building output_subdir values from CSV and GUI inputs to keep session paths portable.