### PR TITLE
Melhora comunicação durante autenticação Coupa

### DIFF
--- a/CoupaTurboDownloader/src/engine/authenticator.py
+++ b/CoupaTurboDownloader/src/engine/authenticator.py
@@ -8,7 +8,7 @@ import threading
 import time
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import httpx
 from selenium import webdriver
@@ -344,6 +344,7 @@ async def get_coupa_cookies(
     headless: bool = False,
     load_from_file: bool = True,
     fresh: bool = False,
+    status_callback: Optional[Callable[[str, str], None]] = None,
 ) -> Dict[str, str]:
     """
     Obtain Coupa session cookies via Selenium Edge.
@@ -352,6 +353,11 @@ async def get_coupa_cookies(
     login including SSO/OAuth flow. System validates cookies by navigating to
     a PO page, then extracts and caches them.
     """
+    def report_status(state: str, message: str) -> None:
+        if status_callback:
+            status_callback(state, message)
+
+    report_status("starting", "Opening Edge and loading Coupa…")
     if fresh:
         cleared = clear_cached_authentication(remove_app_profile=True)
         if not cleared.get("success"):
@@ -361,6 +367,7 @@ async def get_coupa_cookies(
     if load_from_file:
         cached = load_cached_cookies()
         if cached and await validate_cookies(cached):
+            report_status("success", "Cached Coupa session is valid.")
             return cached
 
     print("\n" + "=" * 60)
@@ -371,6 +378,7 @@ async def get_coupa_cookies(
     print("=" * 60 + "\n")
 
     driver = _start_edge_with_profile(headless, prefer_existing=True)
+    report_status("browser_ready", "Edge is open; checking the Coupa page…")
 
     def _safe_current_url_lower() -> str:
         try:
@@ -405,6 +413,11 @@ async def get_coupa_cookies(
         except WebDriverException as exc:
             raise RuntimeError(f"Could not open Coupa in the existing Edge profile: {exc}") from exc
 
+        current_after_navigation = _safe_current_url_lower()
+        if _is_auth_redirect(current_after_navigation):
+            report_status("user_action_required", "Complete the Coupa sign-in in the Edge window.")
+        else:
+            report_status("checking", "Coupa is open; checking the current session…")
         print("[AUTH] Aguardando login (detecao passiva, ENTER para forcar verificacao)...")
 
         enter_event = threading.Event()
@@ -442,6 +455,7 @@ async def get_coupa_cookies(
             on_coupa = "unilever.coupahost.com" in current
             on_auth = _is_auth_redirect(current)
             if on_coupa and not on_auth and _has_coupa_session_cookie():
+                report_status("validating", "Sign-in detected; validating the Coupa session…")
                 break
 
         print("[AUTH] Login detectado! Navegando para o Coupa para capturar cookies de sessao...")
@@ -463,6 +477,7 @@ async def get_coupa_cookies(
         print(f"[AUTH] {len(cookies)} cookies capturados do dominio: {shown_url[:80]}")
         if not cookies.get("_coupa_session"):
             raise RuntimeError("O login foi concluido, mas o cookie de sessao do Coupa nao foi encontrado.")
+        report_status("validating", "Checking access to Coupa and capturing the session…")
         valid, reason = await validate_cookies_detailed(cookies)
         if not valid and reason == "expired":
             raise RuntimeError("O Coupa rejeitou a sessao capturada. Conclua o login e tente novamente.")
@@ -478,6 +493,7 @@ async def get_coupa_cookies(
             pass
         save_cached_cookies_db(cookies)
 
+        report_status("success", "Coupa session captured and validated.")
         print(f"[AUTH] Cookies extraidos e cacheados sem expiracao artificial. Total: {len(cookies)} cookies.")
         print(f"[AUTH] Chaves: {list(cookies.keys())}\n")
         return cookies

--- a/CoupaTurboDownloader/src/gui/web/app.js
+++ b/CoupaTurboDownloader/src/gui/web/app.js
@@ -283,16 +283,37 @@ document.addEventListener("DOMContentLoaded", () => {
         const text = $("#auth-status-text");
         const detailEl = $("#auth-detail");
         const topLabel = $("#topbar-auth-label");
-        indicator.className = `status-dot ${state}`;
+        const visualState = state.startsWith("auth_") ? "authenticating" : state;
+        indicator.className = `status-dot ${visualState}`;
         const pt = appSettings.language === "pt-BR";
         if (state === "authenticated") {
             text.innerText = pt ? "Autenticado" : "Authenticated";
             detailEl.innerText = detail || (pt ? "Sessão Coupa pronta" : "Coupa session ready");
             topLabel.innerText = pt ? "Sessão Coupa pronta" : "Coupa session ready";
+        } else if (state === "auth_starting") {
+            text.innerText = pt ? "Preparando login…" : "Preparing sign-in…";
+            detailEl.innerText = pt ? "Abrindo o Edge e carregando o Coupa" : "Opening Edge and loading Coupa";
+            topLabel.innerText = pt ? "Abrindo o Coupa" : "Opening Coupa";
+        } else if (state === "auth_browser_ready") {
+            text.innerText = pt ? "Verificando o Coupa…" : "Checking Coupa…";
+            detailEl.innerText = pt ? "A página foi carregada; verificando a sessão" : "Page loaded; checking the session";
+            topLabel.innerText = pt ? "Verificando sessão" : "Checking session";
+        } else if (state === "auth_user_action_required") {
+            text.innerText = pt ? "Ação necessária" : "Action required";
+            detailEl.innerText = pt ? "Conclua o login na janela do Edge" : "Complete sign-in in the Edge window";
+            topLabel.innerText = pt ? "Aguardando sua ação" : "Waiting for your action";
+        } else if (state === "auth_checking") {
+            text.innerText = pt ? "Verificando sessão…" : "Checking session…";
+            detailEl.innerText = pt ? "O Coupa está sendo consultado" : "Coupa is being checked";
+            topLabel.innerText = pt ? "Verificando acesso" : "Checking access";
+        } else if (state === "auth_validating") {
+            text.innerText = pt ? "Validando login…" : "Validating sign-in…";
+            detailEl.innerText = pt ? "Login detectado; confirmando acesso ao Coupa" : "Sign-in detected; confirming Coupa access";
+            topLabel.innerText = pt ? "Validando sessão" : "Validating session";
         } else if (state === "authenticating") {
             text.innerText = pt ? "Entrando…" : "Signing in…";
-            detailEl.innerText = pt ? "Conclua o login no Edge" : "Complete login in Edge";
-            topLabel.innerText = pt ? "Aguardando login do Coupa" : "Waiting for Coupa login";
+            detailEl.innerText = pt ? "Preparando a autenticação" : "Preparing authentication";
+            topLabel.innerText = pt ? "Preparando login" : "Preparing sign-in";
         } else if (state === "expired") {
             text.innerText = pt ? "Login necessário" : "Login required";
             detailEl.innerText = pt ? "A sessão em cache expirou" : "Cached session expired";
@@ -307,6 +328,46 @@ document.addEventListener("DOMContentLoaded", () => {
             topLabel.innerText = pt ? "Login necessário" : "Login required";
         }
         $("#btn-authenticate").classList.toggle("is-authenticated", state === "authenticated");
+        const action = $("#btn-authenticate .auth-action");
+        if (action) action.innerText = state === "authenticated" ? (pt ? "Autenticado" : "Ready") : (state.startsWith("auth_") || state === "authenticating" ? (pt ? "Aguarde…" : "Please wait…") : (pt ? "Entrar" : "Sign in"));
+        $("#btn-authenticate").disabled = state.startsWith("auth_") || state === "authenticating";
+    }
+
+    const authStateLabels = {
+        starting: "auth_starting",
+        browser_ready: "auth_browser_ready",
+        user_action_required: "auth_user_action_required",
+        checking: "auth_checking",
+        validating: "auth_validating",
+        success: "authenticated",
+        error: "expired",
+    };
+
+    function normalizeAuthState(state) {
+        return authStateLabels[state] || state || "authenticating";
+    }
+
+    async function authenticateWithProgress() {
+        if (!hasApi("authenticate")) return { success: false, error: "Authentication API unavailable." };
+        updateAuthUI("auth_starting");
+        logToConsole("System", appSettings.language === "pt-BR" ? "Preparando o login do Coupa…" : "Preparing Coupa sign-in…");
+        const started = await api().authenticate();
+        if (!started || !started.success) return started || { success: false, error: "Authentication failed." };
+        if (!hasApi("get_authentication_status")) return started;
+
+        let lastMessage = "";
+        while (true) {
+            const status = await api().get_authentication_status();
+            const uiState = normalizeAuthState(status.state);
+            updateAuthUI(uiState, status.message);
+            if (status.message && status.message !== lastMessage) {
+                logToConsole(uiState === "auth_user_action_required" ? "Warning" : "System", status.message);
+                lastMessage = status.message;
+            }
+            if (status.state === "success") return { success: true };
+            if (status.state === "error") return { success: false, error: status.message || "Authentication failed." };
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
     }
 
     function syncHierarchyLevels(list) {
@@ -732,9 +793,7 @@ document.addEventListener("DOMContentLoaded", () => {
             updateAuthUI("unavailable", authCheck.message);
             logToConsole("Warning", "Session verification is unavailable; the CLI will try the cached Coupa session.");
         } else if (!authCheck.authenticated) {
-            updateAuthUI("authenticating");
-            logToConsole("System", "Login required. Complete the Coupa login in Edge.");
-            const authResult = hasApi("authenticate") ? await api().authenticate() : { success: false, error: "Authentication API unavailable." };
+            const authResult = await authenticateWithProgress();
             if (!authResult.success) {
                 updateAuthUI("expired", authResult.error);
                 logToConsole("Error", authResult.error || "Authentication failed.");
@@ -1275,12 +1334,14 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     $("#btn-authenticate").addEventListener("click", async () => {
-        if (!hasApi("authenticate")) return;
-        updateAuthUI("authenticating");
-        logToConsole("System", "Opening Coupa login…");
-        const result = await api().authenticate();
-        if (result.success) { updateAuthUI("authenticated"); logToConsole("Success", "Coupa authentication successful."); }
-        else { updateAuthUI("expired", result.error); logToConsole("Error", result.error || "Authentication failed."); }
+        const result = await authenticateWithProgress();
+        if (result.success) {
+            updateAuthUI("authenticated");
+            logToConsole("Success", "Coupa authentication successful.");
+        } else {
+            updateAuthUI("expired", result.error);
+            logToConsole("Error", result.error || "Authentication failed.");
+        }
     });
 
     async function initializeAuth() {

--- a/CoupaTurboDownloader/src/main.py
+++ b/CoupaTurboDownloader/src/main.py
@@ -53,27 +53,62 @@ class TurboAPI(AppAPI):
         self.cli_backend = CliProcessSupervisor()
         self._pending_input_path: str | None = None
         self._fresh_auth_requested = False
+        self._auth_lock = threading.Lock()
+        self._auth_thread: threading.Thread | None = None
+        self._auth_status: dict[str, str] = {"state": "idle", "message": ""}
+
+    def _set_auth_status(self, state: str, message: str) -> None:
+        with self._auth_lock:
+            self._auth_status = {"state": state, "message": message}
+
+    def _authenticate_worker(self, fresh: bool) -> None:
+        try:
+            cookies = asyncio.run(get_coupa_cookies(
+                load_from_file=not fresh,
+                fresh=fresh,
+                status_callback=self._set_auth_status,
+            ))
+            self.set_auth_cookies(cookies)
+            self._set_auth_status("success", "Coupa session captured and validated.")
+        except Exception as exc:
+            self._set_auth_status("error", str(exc))
+        finally:
+            with self._auth_lock:
+                self._auth_thread = None
+
+    def get_authentication_status(self) -> dict:
+        with self._auth_lock:
+            return dict(self._auth_status)
 
     def reset_authentication(self) -> dict:
         """Clear app authentication without touching downloads or input files."""
+        with self._auth_lock:
+            if self._auth_thread and self._auth_thread.is_alive():
+                return {"success": False, "error": "Wait for the current Coupa sign-in attempt to finish."}
         result = clear_cached_authentication(remove_app_profile=True)
         if result.get("success"):
             self._cookies = None
             self._fresh_auth_requested = True
+            self._set_auth_status("idle", "Sign-in state reset.")
         return result
 
     def authenticate(self) -> dict:
-        """Open Edge for Coupa login, return extracted cookies dict."""
-        try:
-            cookies = asyncio.run(get_coupa_cookies(
-                load_from_file=not self._fresh_auth_requested,
-                fresh=self._fresh_auth_requested,
-            ))
+        """Start Coupa authentication and expose progress through polling."""
+        with self._auth_lock:
+            if self._auth_thread and self._auth_thread.is_alive():
+                return {"success": True, "started": False, "message": "Authentication is already in progress."}
+            fresh = self._fresh_auth_requested
             self._fresh_auth_requested = False
-            self.set_auth_cookies(cookies)
-            return {"success": True}
-        except Exception as e:
-            return {"success": False, "error": str(e)}
+            self._auth_status = {"state": "starting", "message": "Preparing Coupa sign-in…"}
+            worker = threading.Thread(
+                target=self._authenticate_worker,
+                args=(fresh,),
+                name="coupa-authentication",
+                daemon=True,
+            )
+            self._auth_thread = worker
+            worker.start()
+        return {"success": True, "started": True}
 
     def run_benchmark(self, urls: list[str], base_url: str = "https://unilever.coupahost.com") -> dict:
         """Run network benchmark against sample URLs, return optimal params."""

--- a/CoupaTurboDownloader/tests/test_cli_supervisor.py
+++ b/CoupaTurboDownloader/tests/test_cli_supervisor.py
@@ -87,5 +87,7 @@ def test_history_status_translation_preserves_filter_inputs():
     assert 'id="btn-check-updates"' in html
     assert 'id="btn-start-over"' in html
     assert 'reset_new_run' in javascript
+    assert 'get_authentication_status' in javascript
+    assert 'Action required' in javascript
     assert 'checkForUpdates(true)' in javascript
     assert '$("#modal-pos-tbody").addEventListener("click"' in javascript

--- a/CoupaTurboDownloader/tests/test_gui_api.py
+++ b/CoupaTurboDownloader/tests/test_gui_api.py
@@ -71,6 +71,38 @@ def test_confirm_and_retry_company(temp_db):
     assert po2['status'] == "SUCCESS"
 
 
+def test_authentication_exposes_progress_states_without_blocking(temp_db, monkeypatch):
+    import asyncio
+    import time
+    from src.main import TurboAPI
+
+    async def fake_authenticate(*, load_from_file=True, fresh=False, status_callback=None):
+        status_callback("starting", "Opening Edge and loading Coupa…")
+        await asyncio.sleep(0.08)
+        status_callback("user_action_required", "Complete the Coupa sign-in in the Edge window.")
+        await asyncio.sleep(0.08)
+        status_callback("validating", "Sign-in detected; validating the Coupa session…")
+        return {"_coupa_session": "session-value"}
+
+    monkeypatch.setattr("src.main.get_coupa_cookies", fake_authenticate)
+    api = TurboAPI(temp_db, "/tmp/downloads")
+
+    started = api.authenticate()
+    assert started == {"success": True, "started": True}
+
+    states = []
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        status = api.get_authentication_status()
+        states.append(status["state"])
+        if status["state"] == "success":
+            break
+        time.sleep(0.01)
+
+    assert states[-1] == "success"
+    assert api._cookies == {"_coupa_session": "session-value"}
+
+
 def test_relative_download_path_is_resolved_under_user_home(temp_db, monkeypatch, tmp_path):
     monkeypatch.setattr("src.gui.api.Path.home", lambda: tmp_path)
     api = AppAPI(temp_db, "Downloads/CoupaAttachments")


### PR DESCRIPTION
## Estados de autenticação
- Preparing sign-in: abrindo Edge e carregando Coupa
- Checking Coupa: página carregada, verificando sessão
- Action required: usuário precisa concluir o login
- Validating sign-in: login detectado, confirmando acesso
- Success/error finais

A autenticação agora roda em background e a GUI consulta o estado sem bloquear a janela. O texto técnico não informa mais prematuramente que a ação do usuário é necessária.

## Validação
- 130 testes aprovados
- JavaScript e Python validados

## Summary by Sourcery

Expose Coupa authentication as a non-blocking, multi-step background process with clearer progress and action messaging in the GUI and backend.

New Features:
- Add background Coupa authentication workflow with pollable progress states exposed via TurboAPI.
- Introduce detailed GUI status texts and labels for each authentication phase, including user action requirements and validation steps.

Enhancements:
- Refactor authentication handling in the GUI to centralize progress-driven updates and disable the sign-in button while authentication is in progress.
- Extend the Coupa cookie retrieval engine to report granular authentication status changes via a callback for improved UX.

Tests:
- Add tests to verify non-blocking authentication progress reporting and the new GUI/CLI integration points for Coupa sign-in.