### PR TITLE
fix: concluir commit da PO corrigida

### DIFF
--- a/CoupaTurboDownloader/src/gui/cli_supervisor.py
+++ b/CoupaTurboDownloader/src/gui/cli_supervisor.py
@@ -933,11 +933,11 @@ class CliProcessSupervisor:
                 if str(source["download_folder"] or "").strip() and source_folder.exists() and source_folder != target_folder:
                     shutil.rmtree(source_folder)
                 note = f"Corrected from {attempt['original_po_number']} to {attempt['edited_po_number']}; retry succeeded."
+                conn.execute("DELETE FROM po_downloads WHERE id = ?", (target["id"],))
                 conn.execute(
                     "UPDATE po_downloads SET po_number = ?, status = 'SUCCESS', download_folder = ?, attachment_count = ?, error_message = NULL, remarks = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
                     (attempt["edited_po_number"], str(target_folder), target["attachment_count"], note, source["id"]),
                 )
-                conn.execute("DELETE FROM po_downloads WHERE id = ?", (target["id"],))
                 conn.execute(
                     "UPDATE retry_attempts SET status = 'COMMITTED', completed_at = CURRENT_TIMESTAMP, error_message = ? WHERE id = ?",
                     (note, int(attempt_id)),


### PR DESCRIPTION
Corrige a substituição atômica da linha provisória no banco durante o salvamento da PO editada, evitando conflito na chave única da sessão.

Validação: 131 testes aprovados.

## Summary by Sourcery

Bug Fixes:
- Fix order of database operations when committing a corrected PO so the provisional row is removed before updating the original, preventing unique key violations on the session.