### PR TITLE
fix: aceitar formatos de PO ao salvar retry

### DIFF
--- a/CoupaTurboDownloader/src/gui/cli_supervisor.py
+++ b/CoupaTurboDownloader/src/gui/cli_supervisor.py
@@ -756,6 +756,17 @@ class CliProcessSupervisor:
             return {"success": False, "error": str(exc)}
 
     @staticmethod
+    def _po_values_equal(left: Any, right: Any) -> bool:
+        def normalize(value: Any) -> str:
+            text = str(value or "").strip().upper()
+            text = re.sub(r"\.0+$", "", text)
+            if text.startswith(("PO", "PM")):
+                text = text[2:]
+            return text
+
+        return normalize(left) == normalize(right)
+
+    @staticmethod
     def _replace_po_in_file(path: Path, old_po: str, new_po: str, note: str) -> None:
         if not path.exists():
             raise FileNotFoundError(str(path))
@@ -772,12 +783,17 @@ class CliProcessSupervisor:
                 remarks_index = sheet.max_column + 1
                 sheet.cell(1, remarks_index).value = "REMARKS"
             found = False
+            already_updated = False
             for row in range(2, sheet.max_row + 1):
-                if str(sheet.cell(row, po_index).value or "").strip() == old_po:
+                value = sheet.cell(row, po_index).value
+                if CliProcessSupervisor._po_values_equal(value, old_po):
                     sheet.cell(row, po_index).value = new_po
                     sheet.cell(row, remarks_index).value = note
                     found = True
-            if not found:
+                elif CliProcessSupervisor._po_values_equal(value, new_po):
+                    sheet.cell(row, remarks_index).value = note
+                    already_updated = True
+            if not found and not already_updated:
                 raise ValueError(f"PO {old_po} was not found in {path.name}")
             workbook.save(path)
             return
@@ -789,10 +805,13 @@ class CliProcessSupervisor:
         po_column = next((column for column in frame.columns if re.sub(r"[^a-z0-9]+", "", str(column).lower()) in {"ponumber", "po", "pedido"}), None)
         if po_column is None:
             raise ValueError(f"PO_NUMBER column not found in {path.name}")
-        mask = frame[po_column].astype(str).str.strip().eq(old_po)
-        if not mask.any():
+        values = frame[po_column].astype(str).str.strip()
+        mask = values.map(lambda value: CliProcessSupervisor._po_values_equal(value, old_po))
+        already_updated = values.map(lambda value: CliProcessSupervisor._po_values_equal(value, new_po))
+        if not mask.any() and not already_updated.any():
             raise ValueError(f"PO {old_po} was not found in {path.name}")
         frame.loc[mask, po_column] = new_po
+        mask = mask | already_updated
         remarks_column = next((column for column in frame.columns if re.sub(r"[^a-z0-9]+", "", str(column).lower()) in {"remarks", "observations", "observacao", "observacoes"}), "REMARKS")
         if remarks_column not in frame.columns:
             frame[remarks_column] = ""

--- a/CoupaTurboDownloader/tests/test_cli_supervisor.py
+++ b/CoupaTurboDownloader/tests/test_cli_supervisor.py
@@ -95,6 +95,10 @@ def test_retry_file_update_replaces_po_and_adds_remark(tmp_path):
     row = list(load_workbook(path, read_only=True).active.iter_rows(values_only=True))[1]
     assert row == ("1234567", "ACME", "Corrected from 12345678 to 1234567; retry succeeded.")
 
+    # Existing archived values may have a PO prefix or numeric Excel formatting.
+    assert CliProcessSupervisor._po_values_equal("168012998", "PO168012998")
+    assert CliProcessSupervisor._po_values_equal("168012998.0", "PO168012998")
+
 
 def test_history_status_translation_preserves_filter_inputs():
     web_root = Path(__file__).parents[1] / "src" / "gui" / "web"


### PR DESCRIPTION
Corrige a persistência quando a PO no Excel está sem prefixo, com prefixo PO/PM, com espaços ou com formatação numérica do Excel. Também torna o salvamento idempotente caso uma etapa anterior já tenha atualizado o arquivo.

131 testes aprovados.

## Summary by Sourcery

Handle purchase order retries robustly when PO values have prefixes or Excel numeric formatting and avoid failing when the file was already updated.

New Features:
- Support PO values with PO/PM prefixes, extra spaces, or Excel numeric formatting when updating retry files.

Bug Fixes:
- Prevent retry file updates from failing when the target PO is stored with a different textual or numeric representation.
- Avoid raising an error when the retry file has already been updated for the given PO by reusing existing remarks instead.

Tests:
- Extend CLI supervisor tests to cover PO value normalization and equivalence for prefixed and numerically formatted Excel values.