### PR TITLE
fix: tornar launcher Windows portátil autocontido

### DIFF
--- a/CoupaTurboDownloader/build_python_portable.py
+++ b/CoupaTurboDownloader/build_python_portable.py
@@ -101,12 +101,56 @@ def _copy_application() -> None:
 
 
 def _write_launchers() -> None:
+    (APP_DIR / "launcher.py").write_text(
+        '''from __future__ import annotations
+
+import ctypes
+import runpy
+import traceback
+from datetime import datetime
+from pathlib import Path
+
+BUNDLE_DIR = Path(__file__).resolve().parent.parent
+MAIN = BUNDLE_DIR / "app" / "src" / "main.py"
+LOG = BUNDLE_DIR / "startup.log"
+
+
+def write_log(message: str) -> None:
+    try:
+        with LOG.open("a", encoding="utf-8") as stream:
+            stream.write(f"[{datetime.now().isoformat(timespec='seconds')}] {message}\\n")
+    except OSError:
+        pass
+
+
+write_log("Starting Coupa Turbo Downloader")
+try:
+    runpy.run_path(str(MAIN), run_name="__main__")
+except Exception:
+    details = traceback.format_exc()
+    write_log(details)
+    try:
+        ctypes.windll.user32.MessageBoxW(
+            0,
+            "Coupa Turbo Downloader could not start.\\n\\nSee startup.log in the application folder.",
+            "Coupa Turbo Downloader",
+            0x10,
+        )
+    except Exception:
+        pass
+    raise
+''',
+        encoding="utf-8",
+    )
     (BUNDLE_DIR / "Start-CoupaTurbo.cmd").write_text(
         "@echo off\r\n"
         "setlocal\r\n"
         "set \"COUPA_PYTHON_PORTABLE=1\"\r\n"
         "cd /d \"%~dp0\"\r\n"
-        "start \"Coupa Turbo Downloader\" \"%~dp0runtime\\pythonw.exe\" \"%~dp0app\\src\\main.py\"\r\n",
+        "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"try { $root = [IO.Path]::GetFullPath($args[0]); Get-ChildItem -LiteralPath $root -Recurse -File | Unblock-File; exit 0 } catch { $_ | Out-File -FilePath ([IO.Path]::Combine($root, 'startup.log')) -Append; exit 1 }\" \"%~dp0\"\r\n"
+        "if not exist \"%~dp0runtime\\pythonw.exe\" (echo Portable Python runtime was not found. & pause & exit /b 1)\r\n"
+        "start \"Coupa Turbo Downloader\" \"%~dp0runtime\\pythonw.exe\" \"%~dp0app\\launcher.py\"\r\n"
+        "exit /b 0\r\n",
         encoding="ascii",
     )
     (BUNDLE_DIR / "Run-Diagnostics.cmd").write_text(
@@ -143,7 +187,8 @@ def _write_launchers() -> None:
         "official Python Software Foundation embedded distribution.\n\n"
         "Automatic update checks are disabled by default in this edition.\n"
         "Use Settings > Updates > Check now for a manual verified update.\n"
-        "Application data and downloads remain outside this folder.\n",
+        "Application data and downloads remain outside this folder.\n"
+        "If the GUI does not open, check startup.log in this folder.\n",
         encoding="utf-8",
     )
 

--- a/CoupaTurboDownloader/tests/test_python_portable_build.py
+++ b/CoupaTurboDownloader/tests/test_python_portable_build.py
@@ -32,8 +32,12 @@ def test_portable_launcher_uses_official_pythonw_and_manual_updates(monkeypatch,
     portable._write_launchers()
 
     launcher = (bundle / "Start-CoupaTurbo.cmd").read_text(encoding="ascii")
+    python_launcher = (app / "launcher.py").read_text(encoding="utf-8")
     metadata = json.loads((bundle / "portable-python.json").read_text(encoding="utf-8"))
     assert "COUPA_PYTHON_PORTABLE=1" in launcher
+    assert "Unblock-File" in launcher
     assert "runtime\\pythonw.exe" in launcher
+    assert "startup.log" in launcher
+    assert "runpy.run_path" in python_launcher
     assert metadata["automatic_update_check_default"] is False
     assert metadata["manual_updates"] is True


### PR DESCRIPTION
O launcher agora: 
- desbloqueia automaticamente os arquivos extraídos pelo Windows;
- inicia uma camada Python com registro em startup.log;
- mostra uma mensagem nativa se a GUI falhar;
- preserva o início por duplo clique no .cmd.

Validação: testes do launcher, compilação Python e diff check aprovados.

## Summary by Sourcery

Make the Windows portable launcher more robust and self-contained with logging, file unblocking, and improved startup behavior.

New Features:
- Introduce a Python launcher entrypoint that logs startup events and reports GUI failures via a native Windows message box.
- Add automatic unblocking of extracted files in the portable bundle before starting the application.

Enhancements:
- Update the portable bundle readme to reference startup.log for troubleshooting GUI startup issues.
- Ensure the CMD launcher verifies the presence of the portable Python runtime and exits with an appropriate status code.

Tests:
- Extend portable launcher build tests to cover the new Python launcher script, file unblocking, and startup logging behavior.