### PR TITLE
fix: corrigir desbloqueio automático do launcher

### DIFF
--- a/CoupaTurboDownloader/build_python_portable.py
+++ b/CoupaTurboDownloader/build_python_portable.py
@@ -147,7 +147,7 @@ except Exception:
         "setlocal\r\n"
         "set \"COUPA_PYTHON_PORTABLE=1\"\r\n"
         "cd /d \"%~dp0\"\r\n"
-        "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"try { $root = [IO.Path]::GetFullPath($args[0]); Get-ChildItem -LiteralPath $root -Recurse -File | Unblock-File; exit 0 } catch { $_ | Out-File -FilePath ([IO.Path]::Combine($root, 'startup.log')) -Append; exit 1 }\" \"%~dp0\"\r\n"
+        "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"$ErrorActionPreference = 'Stop'; try { Get-ChildItem -LiteralPath '%~dp0' -Recurse -File | Unblock-File; exit 0 } catch { $_ | Out-File -FilePath '%~dp0startup.log' -Append; exit 1 }\"\r\n"
         "if not exist \"%~dp0runtime\\pythonw.exe\" (echo Portable Python runtime was not found. & pause & exit /b 1)\r\n"
         "start \"Coupa Turbo Downloader\" \"%~dp0runtime\\pythonw.exe\" \"%~dp0app\\launcher.py\"\r\n"
         "exit /b 0\r\n",


### PR DESCRIPTION
Ajusta o comando PowerShell do launcher para usar diretamente o caminho do bundle, tornando o Unblock-File confiável em paths com espaços.

Isso cobre o erro Python.Runtime.Loader.Initialize causado por DLLs bloqueadas pelo Mark-of-the-Web.

## Summary by Sourcery

Improve the launcher’s startup script to reliably unblock bundled files and avoid initialization failures caused by blocked DLLs.

Bug Fixes:
- Fix automatic file unblocking in the launcher so that Unblock-File works correctly when the bundle path contains spaces.

Enhancements:
- Simplify the PowerShell invocation in the launcher script by operating directly on the bundle directory and enforcing stop-on-error behavior.