### PR TITLE
fix: evitar caminho longo no bundle Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,10 @@ jobs:
 
       - name: Package Python portable release
         shell: pwsh
-        run: Compress-Archive -Path dist/CoupaTurboDownloader-python-portable -DestinationPath dist/CoupaTurboDownloader-windows-python-portable-x64.zip -Force
+        run: |
+          Push-Location dist/CoupaTurboDownloader-python-portable
+          Compress-Archive -Path * -DestinationPath ../CoupaTurboDownloader-windows-python-portable-x64.zip -Force
+          Pop-Location
 
       - name: Upload Python portable package
         uses: actions/upload-artifact@v4

--- a/CoupaTurboDownloader/build_python_portable.py
+++ b/CoupaTurboDownloader/build_python_portable.py
@@ -90,6 +90,15 @@ def _install_dependencies() -> None:
     subprocess.check_call(command, cwd=PROJECT_ROOT)
 
 
+def _prune_windows_long_path_resources() -> None:
+    """Remove optional lxml resources that trigger Explorer's 260-char limit."""
+    optional_paths = [
+        RUNTIME_DIR / "Lib" / "site-packages" / "lxml" / "isoschematron",
+    ]
+    for path in optional_paths:
+        shutil.rmtree(path, ignore_errors=True)
+
+
 def _copy_application() -> None:
     shutil.copytree(
         PROJECT_ROOT / "src",
@@ -234,6 +243,7 @@ def build() -> Path:
         archive.extractall(RUNTIME_DIR)
     _configure_runtime()
     _install_dependencies()
+    _prune_windows_long_path_resources()
     _copy_application()
     _write_launchers()
     _smoke_test()


### PR DESCRIPTION
Remove recursos opcionais longos do lxml que não são usados pela aplicação e empacota o conteúdo portátil sem uma pasta interna adicional. Isso evita o erro 0x80010135 durante a extração pelo Explorer.

O uso imediato continua possível extraindo em C:\CTD ou usando 7-Zip.

## Summary by Sourcery

Prune unnecessary lxml resources from the Windows Python portable bundle and adjust the CI packaging to avoid exceeding Windows path length limits during extraction.

Bug Fixes:
- Remove unused lxml optional resources from the portable runtime to prevent Windows Explorer hitting the 260-character path limit when extracting the archive.

CI:
- Change the Windows portable packaging step to zip the contents of the portable directory directly instead of nesting them under an extra top-level folder.