### PR TITLE
feat: renomear aplicativo para Contract Downloader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,20 +58,20 @@ jobs:
       - name: Verify Windows executable
         shell: pwsh
         run: |
-          if (-not (Test-Path "dist/CoupaTurboDownloader.exe")) {
+          if (-not (Test-Path "dist/ContractDownloader.exe")) {
             throw "Windows executable was not generated"
           }
-          Get-Item "dist/CoupaTurboDownloader.exe" | Format-List Name,Length,LastWriteTime
+          Get-Item "dist/ContractDownloader.exe" | Format-List Name,Length,LastWriteTime
 
       - name: Package Windows release
         shell: pwsh
-        run: Compress-Archive -Path dist/CoupaTurboDownloader.exe -DestinationPath dist/CoupaTurboDownloader-windows-x64.zip -Force
+        run: Compress-Archive -Path dist/ContractDownloader.exe -DestinationPath dist/ContractDownloader-windows-x64.zip -Force
 
       - name: Upload Windows package
         uses: actions/upload-artifact@v4
         with:
-          name: windows-package
-          path: CoupaTurboDownloader/dist/CoupaTurboDownloader-windows-x64.zip
+          name: contract-downloader-windows
+          path: CoupaTurboDownloader/dist/ContractDownloader-windows-x64.zip
           if-no-files-found: error
           retention-days: 14
 
@@ -81,8 +81,8 @@ jobs:
       - name: Verify official Python signatures
         shell: pwsh
         run: |
-          $python = Get-AuthenticodeSignature "dist/CoupaTurboDownloader-python-portable/runtime/python.exe"
-          $pythonw = Get-AuthenticodeSignature "dist/CoupaTurboDownloader-python-portable/runtime/pythonw.exe"
+          $python = Get-AuthenticodeSignature "dist/ContractDownloader-python-portable/runtime/python.exe"
+          $pythonw = Get-AuthenticodeSignature "dist/ContractDownloader-python-portable/runtime/pythonw.exe"
           if ($python.Status -ne "Valid" -or $pythonw.Status -ne "Valid") {
             throw "Official embedded Python executables do not have valid Authenticode signatures"
           }
@@ -91,15 +91,15 @@ jobs:
       - name: Package Python portable release
         shell: pwsh
         run: |
-          Push-Location dist/CoupaTurboDownloader-python-portable
-          Compress-Archive -Path * -DestinationPath ../CoupaTurboDownloader-windows-python-portable-x64.zip -Force
+          Push-Location dist/ContractDownloader-python-portable
+          Compress-Archive -Path * -DestinationPath ../ContractDownloader-windows-python-portable-x64.zip -Force
           Pop-Location
 
       - name: Upload Python portable package
         uses: actions/upload-artifact@v4
         with:
-          name: windows-python-portable
-          path: CoupaTurboDownloader/dist/CoupaTurboDownloader-windows-python-portable-x64.zip
+          name: contract-downloader-windows-portable
+          path: CoupaTurboDownloader/dist/ContractDownloader-windows-python-portable-x64.zip
           if-no-files-found: error
           retention-days: 14
 
@@ -132,16 +132,16 @@ jobs:
         run: uv run --package coupaturbodownloader --group build python build.py --macos
 
       - name: Verify macOS application
-        run: test -d dist/CoupaTurboDownloader.app
+        run: test -d dist/ContractDownloader.app
 
       - name: Package macOS release
-        run: ditto -c -k --sequesterRsrc --keepParent dist/CoupaTurboDownloader.app dist/CoupaTurboDownloader-macos.zip
+        run: ditto -c -k --sequesterRsrc --keepParent dist/ContractDownloader.app dist/ContractDownloader-macos.zip
 
       - name: Upload macOS package
         uses: actions/upload-artifact@v4
         with:
-          name: macos-package
-          path: CoupaTurboDownloader/dist/CoupaTurboDownloader-macos.zip
+          name: contract-downloader-macos
+          path: CoupaTurboDownloader/dist/ContractDownloader-macos.zip
           if-no-files-found: error
           retention-days: 14
 
@@ -159,19 +159,19 @@ jobs:
       - name: Download Windows package
         uses: actions/download-artifact@v4
         with:
-          name: windows-package
+          name: contract-downloader-windows
           path: release-assets
 
       - name: Download Python portable package
         uses: actions/download-artifact@v4
         with:
-          name: windows-python-portable
+          name: contract-downloader-windows-portable
           path: release-assets
 
       - name: Download macOS package
         uses: actions/download-artifact@v4
         with:
-          name: macos-package
+          name: contract-downloader-macos
           path: release-assets
 
       - name: Generate checksums

--- a/CoupaTurboDownloader/ContractDownloader.command
+++ b/CoupaTurboDownloader/ContractDownloader.command
@@ -1,0 +1,23 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+
+# Ensure uv is available
+if ! command -v uv &> /dev/null; then
+    echo "ERROR: 'uv' not found. Please install it first:"
+    echo "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+    read -p "Press Enter to close..."
+    exit 1
+fi
+
+echo "========================================"
+echo "  Contract Downloader — Starting GUI"
+echo "========================================"
+
+uv run coupa-turbo
+
+# Keep terminal open briefly so user can see any errors
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "Application exited with errors (code $?)."
+    read -p "Press Enter to close..."
+fi

--- a/CoupaTurboDownloader/ContractDownloader.spec
+++ b/CoupaTurboDownloader/ContractDownloader.spec
@@ -1,0 +1,51 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['/Users/juliocezar/Dev/CoupaPilot/CoupaTurboDownloader/src/main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('/Users/juliocezar/Dev/CoupaPilot/CoupaTurboDownloader/src/gui/web', 'gui/web'), ('/Users/juliocezar/Dev/CoupaPilot/CoupaTurboDownloader/.version', '.')],
+    hiddenimports=['extract_msg', 'fpdf', 'bs4', 'lxml', 'pandas', 'openpyxl', 'httpx', 'webview', 'selenium', 'selenium.webdriver.edge', 'selenium.webdriver.edge.webdriver', 'asyncio', 'json', 'sqlite3', 'process_all_pos'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='ContractDownloader',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['/Users/juliocezar/Dev/CoupaPilot/CoupaTurboDownloader/icon.icns'],
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='ContractDownloader',
+)
+app = BUNDLE(
+    coll,
+    name='ContractDownloader.app',
+    icon='/Users/juliocezar/Dev/CoupaPilot/CoupaTurboDownloader/icon.icns',
+    bundle_identifier='com.coupapilot.turbodownloader',
+)

--- a/CoupaTurboDownloader/build.py
+++ b/CoupaTurboDownloader/build.py
@@ -1,5 +1,5 @@
 """
-Build script for CoupaTurboDownloader portable executables.
+Build script for Contract Downloader portable executables.
 
 Usage:
     uv run --group build python build.py          # build for current OS
@@ -20,7 +20,7 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent
-APP_NAME = "CoupaTurboDownloader"
+APP_NAME = "ContractDownloader"
 ENTRY_POINT = str(PROJECT_ROOT / "src" / "main.py")
 WEB_ASSETS_SRC = str(PROJECT_ROOT / "src" / "gui" / "web")
 # The frozen app resolves assets from _MEIPASS/gui/web. Keep the package
@@ -168,7 +168,7 @@ def build():
 
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description="Build CoupaTurboDownloader executable")
+    parser = argparse.ArgumentParser(description="Build Contract Downloader executable")
     parser.add_argument(
         "--macos", action="store_true",
         help="Build for macOS (default on macOS)"

--- a/CoupaTurboDownloader/build_python_portable.py
+++ b/CoupaTurboDownloader/build_python_portable.py
@@ -21,7 +21,9 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 DIST_DIR = PROJECT_ROOT / "dist"
-BUNDLE_NAME = "CoupaTurboDownloader-python-portable"
+PRODUCT_NAME = "Contract Downloader"
+PRODUCT_SLUG = "ContractDownloader"
+BUNDLE_NAME = "ContractDownloader-python-portable"
 BUNDLE_DIR = DIST_DIR / BUNDLE_NAME
 RUNTIME_DIR = BUNDLE_DIR / "runtime"
 APP_DIR = BUNDLE_DIR / "app"
@@ -132,7 +134,7 @@ def write_log(message: str) -> None:
         pass
 
 
-write_log("Starting Coupa Turbo Downloader")
+write_log("Starting Contract Downloader")
 try:
     runpy.run_path(str(MAIN), run_name="__main__")
 except Exception:
@@ -141,8 +143,8 @@ except Exception:
     try:
         ctypes.windll.user32.MessageBoxW(
             0,
-            "Coupa Turbo Downloader could not start.\\n\\nSee startup.log in the application folder.",
-            "Coupa Turbo Downloader",
+            "Contract Downloader could not start.\\n\\nSee startup.log in the application folder.",
+            "Contract Downloader",
             0x10,
         )
     except Exception:
@@ -151,18 +153,18 @@ except Exception:
 ''',
         encoding="utf-8",
     )
-    (BUNDLE_DIR / "Start-CoupaTurbo.cmd").write_text(
+    (BUNDLE_DIR / "Start-ContractDownloader.cmd").write_text(
         "@echo off\r\n"
         "setlocal\r\n"
         "set \"COUPA_PYTHON_PORTABLE=1\"\r\n"
         "cd /d \"%~dp0\"\r\n"
         "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"$ErrorActionPreference = 'Stop'; try { Get-ChildItem -LiteralPath '%~dp0' -Recurse -File | Unblock-File; exit 0 } catch { $_ | Out-File -FilePath '%~dp0startup.log' -Append; exit 1 }\"\r\n"
         "if not exist \"%~dp0runtime\\pythonw.exe\" (echo Portable Python runtime was not found. & pause & exit /b 1)\r\n"
-        "start \"Coupa Turbo Downloader\" \"%~dp0runtime\\pythonw.exe\" \"%~dp0app\\launcher.py\"\r\n"
+        "start \"Contract Downloader\" \"%~dp0runtime\\pythonw.exe\" \"%~dp0app\\launcher.py\"\r\n"
         "exit /b 0\r\n",
         encoding="ascii",
     )
-    (BUNDLE_DIR / "Run-Diagnostics.cmd").write_text(
+    (BUNDLE_DIR / "ContractDownloader-Diagnostics.cmd").write_text(
         "@echo off\r\n"
         "setlocal\r\n"
         "set \"COUPA_PYTHON_PORTABLE=1\"\r\n"
@@ -171,11 +173,11 @@ except Exception:
         "pause\r\n",
         encoding="ascii",
     )
-    (BUNDLE_DIR / "portable-python.json").write_text(
+    (BUNDLE_DIR / "contract-downloader.json").write_text(
         json.dumps(
             {
                 "format": 1,
-                "application": "CoupaTurboDownloader",
+                "application": PRODUCT_NAME,
                 "python": PYTHON_VERSION,
                 "architecture": "x86_64",
                 "automatic_update_check_default": False,
@@ -185,20 +187,17 @@ except Exception:
         ),
         encoding="utf-8",
     )
-    (BUNDLE_DIR / "PORTABLE_README.txt").write_text(
-        "Coupa Turbo Downloader - Python portable edition\n"
-        "=================================================\n\n"
-        "1. Extract the complete folder.\n"
-        "2. Run Start-CoupaTurbo.cmd.\n"
-        "3. Keep runtime/ and app/ beside the launcher.\n\n"
-        "Python installation and administrator privileges are not required.\n"
-        "The runtime/python.exe and runtime/pythonw.exe files come from the\n"
-        "official Python Software Foundation embedded distribution.\n\n"
-        "Automatic update checks are disabled by default in this edition.\n"
-        "Use Settings > Updates > Check now for a manual verified update.\n"
-        "Application data and downloads remain outside this folder.\n"
-        "If the GUI does not open, check startup.log in this folder.\n",
+    (BUNDLE_DIR / "LEIA-ME.txt").write_text(
+        "Contract Downloader - Windows portable edition\n"
+        "===============================================\n\n"
+        "Leia as instruções do arquivo INSTRUCOES_CONTRACT_DOWNLOADER.md antes de iniciar.\n\n"
+        "Não é necessário instalar Python ou executar como administrador.\n"
+        "Se o aplicativo não abrir, verifique startup.log nesta pasta.\n",
         encoding="utf-8",
+    )
+    shutil.copy2(
+        PROJECT_ROOT / "docs" / "INSTRUCOES_CONTRACT_DOWNLOADER.md",
+        BUNDLE_DIR / "INSTRUCOES_CONTRACT_DOWNLOADER.md",
     )
 
 

--- a/CoupaTurboDownloader/docs/INSTRUCOES_CONTRACT_DOWNLOADER.md
+++ b/CoupaTurboDownloader/docs/INSTRUCOES_CONTRACT_DOWNLOADER.md
@@ -1,0 +1,66 @@
+# Contract Downloader — instruções rápidas
+
+## 1. Baixar e extrair
+
+1. Baixe o arquivo ZIP enviado pela equipe.
+2. Extraia **todo o conteúdo** do ZIP. Não execute o aplicativo de dentro do ZIP.
+3. Se o Windows informar **Erro 0x80010135: caminho muito longo**, extraia em uma pasta curta, por exemplo:
+
+   `C:\ContractDownloader`
+
+Não renomeie nem remova as pastas `runtime` e `app`.
+
+## 2. Iniciar o aplicativo
+
+Abra duas vezes o arquivo:
+
+`Start-ContractDownloader.cmd`
+
+Não é necessário instalar Python, instalar bibliotecas ou executar como administrador.
+
+Na primeira abertura, o Windows pode demorar alguns segundos para preparar o aplicativo.
+
+## 3. Fazer o login
+
+Quando solicitado:
+
+1. Conclua o login do Coupa na janela do Edge.
+2. Retorne ao Contract Downloader.
+3. Aguarde a confirmação da sessão.
+
+## 4. Executar uma lista de POs
+
+1. Escolha o arquivo Excel ou CSV de input.
+2. Valide o arquivo.
+3. Escolha a estrutura de pastas.
+4. Escolha a pasta de destino.
+5. Revise as informações e clique em **Start download**.
+
+O arquivo original de input é preservado durante a execução.
+
+## 5. Corrigir uma PO com erro
+
+1. Abra **Run History**.
+2. Abra os detalhes da execução.
+3. Clique em **Retry** na PO com erro.
+4. Corrija o número da PO e confirme.
+5. Se o retry funcionar, escolha **Save correction** para atualizar o input e o relatório.
+6. Escolha **Discard retry** somente se não quiser manter os arquivos baixados nem a correção.
+
+## 6. Se o aplicativo não abrir
+
+1. Verifique o arquivo `startup.log` na pasta do aplicativo.
+2. Execute `ContractDownloader-Diagnostics.cmd`.
+3. Envie o conteúdo de `startup.log` e o relatório de diagnóstico para a equipe de suporte.
+
+Não apague `runtime`, `app` ou os arquivos `.cmd`.
+
+## 7. Arquivos importantes
+
+- `Start-ContractDownloader.cmd`: inicia o aplicativo.
+- `ContractDownloader-Diagnostics.cmd`: gera um diagnóstico do ambiente.
+- `startup.log`: registra problemas de inicialização.
+- `runtime`: Python portátil usado pelo aplicativo.
+- `app`: arquivos do Contract Downloader.
+
+Downloads, autenticação, histórico e configurações são armazenados fora da pasta do aplicativo.

--- a/CoupaTurboDownloader/main.py
+++ b/CoupaTurboDownloader/main.py
@@ -1,5 +1,5 @@
 def main():
-    print("Hello from coupaturbodownloader!")
+    print("Hello from Contract Downloader!")
 
 
 if __name__ == "__main__":

--- a/CoupaTurboDownloader/src/engine/updater.py
+++ b/CoupaTurboDownloader/src/engine/updater.py
@@ -17,6 +17,7 @@ import httpx
 GITHUB_REPOSITORY = os.environ.get("COUPA_UPDATE_REPO", "CzarX86/CoupaPilot")
 GITHUB_API = f"https://api.github.com/repos/{GITHUB_REPOSITORY}/releases/latest"
 VERSION_FILE = os.path.join(os.path.dirname(__file__), "..", "..", ".version")
+PORTABLE_MARKERS = ("contract-downloader.json", "portable-python.json")
 
 
 def _version_path() -> Path:
@@ -42,7 +43,7 @@ def _python_portable_root() -> Optional[Path]:
     if os.environ.get("COUPA_PYTHON_PORTABLE") != "1":
         return None
     candidate = Path(sys.executable).resolve().parent.parent
-    return candidate if (candidate / "portable-python.json").is_file() else None
+    return candidate if any((candidate / marker).is_file() for marker in PORTABLE_MARKERS) else None
 
 
 def _find_platform_asset(assets: list) -> Optional[dict]:
@@ -96,7 +97,7 @@ async def check_for_update() -> Optional[Dict[str, Any]]:
             return {
                 "version": latest,
                 "current": current,
-                "name": release.get("name") or f"Coupa Turbo Downloader {latest}",
+                "name": release.get("name") or f"Contract Downloader {latest}",
                 "download_url": asset["browser_download_url"],
                 "asset_name": asset.get("name", "update.zip"),
                 "checksum_url": checksum_asset.get("browser_download_url") if checksum_asset else None,
@@ -178,7 +179,7 @@ def _find_update_payload(extracted: Path) -> Path:
         if candidates:
             return candidates[0]
     elif sys.platform == "win32":
-        portable_roots = [marker.parent for marker in extracted.rglob("portable-python.json")]
+        portable_roots = [marker.parent for marker_name in PORTABLE_MARKERS for marker in extracted.rglob(marker_name)]
         if _python_portable_root() is not None and portable_roots:
             return portable_roots[0]
         candidates = [path for path in extracted.rglob("*.exe") if path.name.lower() != "uninstall.exe"]
@@ -242,11 +243,13 @@ def apply_update_and_restart(new_payload: str) -> None:
     if sys.platform == "win32":
         portable_root = _python_portable_root()
         if portable_root is not None:
-            if not (payload / "portable-python.json").is_file():
+            if not any((payload / marker).is_file() for marker in PORTABLE_MARKERS):
                 raise OSError("The update is not a Python portable package.")
             target = portable_root
             backup = target.with_name(f".{target.name}.backup")
-            launcher = target / "Start-CoupaTurbo.cmd"
+            launcher = target / "Start-ContractDownloader.cmd"
+            if not launcher.is_file():
+                launcher = target / "Start-CoupaTurbo.cmd"
             staging = payload.parent
             script = "\n".join([
                 "@echo off",

--- a/CoupaTurboDownloader/src/gui/api.py
+++ b/CoupaTurboDownloader/src/gui/api.py
@@ -784,7 +784,7 @@ class AppAPI:
         failed = sum(item["status"] == "FAIL" for item in checks)
         warnings = sum(item["status"] == "WARN" for item in checks)
         lines = [
-            "COUPA TURBO DOWNLOADER - HOST DIAGNOSTIC REPORT",
+            "CONTRACT DOWNLOADER - HOST DIAGNOSTIC REPORT",
             f"Generated: {datetime.now(timezone.utc).isoformat()}",
             "",
             f"Summary: {passed} pass | {warnings} warning(s) | {failed} failure(s)",
@@ -859,7 +859,7 @@ class AppAPI:
         if not value:
             return {"success": True, "deleted": False, "preserved": False}
         path = Path(value).expanduser().resolve()
-        template_dir = (Path.home() / "Documents" / "CoupaTurboDownloader" / "templates").resolve()
+        template_dir = (Path.home() / "Documents" / "Contract Downloader" / "templates").resolve()
         is_generated_template = (
             path.parent == template_dir
             and re.fullmatch(r"input_template_\d{8}-\d{6}\.xlsx", path.name) is not None
@@ -878,7 +878,7 @@ class AppAPI:
         Creates a file next to the default input CSV location with a timestamp
         so the user can fill it out without overwriting anything.
         """
-        template_dir = Path.home() / "Documents" / "CoupaTurboDownloader" / "templates"
+        template_dir = Path.home() / "Documents" / "Contract Downloader" / "templates"
         template_dir.mkdir(parents=True, exist_ok=True)
 
         timestamp = time.strftime("%Y%m%d-%H%M%S")
@@ -914,7 +914,7 @@ class AppAPI:
         instructions = workbook.create_sheet("Instructions")
         instructions.column_dimensions["A"].width = 24
         instructions.column_dimensions["B"].width = 100
-        instructions.append(["Coupa Turbo Downloader — input guide", ""])
+        instructions.append(["Contract Downloader — input guide", ""])
         instructions.append(["Required fields", "PO_NUMBER and SUPPLIER must be filled for every row."])
         instructions.append(["The <|> separator", "Columns before <|> identify the PO. Columns after <|> define the destination folder hierarchy."])
         instructions.append(["Folder levels", "The first column after <|> is level 1, the next is level 2, and so on. Blank values become Unknown."])

--- a/CoupaTurboDownloader/src/gui/web/app.js
+++ b/CoupaTurboDownloader/src/gui/web/app.js
@@ -136,7 +136,7 @@ document.addEventListener("DOMContentLoaded", () => {
         setMany(".engine-status span:last-child", [pt ? "Motor pronto" : "Engine ready"]);
         setMany("#btn-diagnostics", [pt ? "Executar diagnóstico do computador" : "Run host diagnostics"]);
         setMany(".auth-action", [pt ? "Entrar" : "Sign in"]);
-        $("#screen-learn h2").innerText = appSettings.language === "pt-BR" ? "Como o Coupa Turbo funciona" : "How Coupa Turbo works";
+        $("#screen-learn h2").innerText = appSettings.language === "pt-BR" ? "Como o Contract Downloader funciona" : "How Contract Downloader works";
         $("#screen-settings h2").innerText = appSettings.language === "pt-BR" ? "Preferências" : "Preferences";
         const languageOption = $("#settings-language option[value='pt-BR']");
         if (languageOption) languageOption.innerText = "Português (Brasil)";

--- a/CoupaTurboDownloader/src/gui/web/index.html
+++ b/CoupaTurboDownloader/src/gui/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Coupa Turbo Downloader</title>
+    <title>Contract Downloader</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -12,8 +12,8 @@
             <div class="brand">
                 <div class="brand-mark">CT</div>
                 <div>
-                    <strong>Coupa Turbo</strong>
-                    <span>Attachment workspace</span>
+                    <strong>Contract Downloader</strong>
+                    <span>Contract attachment workspace</span>
                 </div>
             </div>
 
@@ -123,7 +123,7 @@
             </section>
 
             <section class="screen" id="screen-learn" hidden>
-                <div class="intro-block"><div><p class="eyebrow">LEARN</p><h2>How Coupa Turbo works</h2><p>A practical guide to prepare inputs, download attachments, and recover safely from errors.</p></div></div>
+                <div class="intro-block"><div><p class="eyebrow">LEARN</p><h2>How Contract Downloader works</h2><p>A practical guide to prepare inputs, download attachments, and recover safely from errors.</p></div></div>
                 <div class="learn-grid">
                     <article class="learn-card"><span class="learn-icon">01</span><h3>Prepare the input</h3><p>Use an Excel or CSV file with <code>PO_NUMBER</code> and <code>SUPPLIER</code>. The template includes an <code>&lt;|&gt;</code> separator. Save and close Excel before validating.</p><div class="learn-note">Columns after <code>&lt;|&gt;</code> become folder levels. Blank required fields are reported before any download starts.</div></article>
                     <article class="learn-card"><span class="learn-icon">02</span><h3>Follow the journey</h3><p>The New Run journey has five stages: input, validation, folders, destination, and review. A run is created only after the final confirmation.</p><div class="learn-note">Completed steps remain available for navigation; future steps explain what is still missing.</div></article>

--- a/CoupaTurboDownloader/src/main.py
+++ b/CoupaTurboDownloader/src/main.py
@@ -371,7 +371,7 @@ def main():
     )
 
     window = webview.create_window(
-        title="Coupa Turbo Downloader",
+        title="Contract Downloader",
         url=html_file,
         js_api=api,
         width=geometry["width"],

--- a/CoupaTurboDownloader/tests/test_gui_api.py
+++ b/CoupaTurboDownloader/tests/test_gui_api.py
@@ -175,7 +175,7 @@ def test_font_scale_setting_is_validated_and_persisted(temp_db, monkeypatch, tmp
 
 def test_reset_new_run_deletes_only_app_generated_template(temp_db, monkeypatch, tmp_path):
     monkeypatch.setattr("src.gui.api.Path.home", lambda: tmp_path)
-    template_dir = tmp_path / "Documents" / "CoupaTurboDownloader" / "templates"
+    template_dir = tmp_path / "Documents" / "Contract Downloader" / "templates"
     template_dir.mkdir(parents=True)
     generated = template_dir / "input_template_20260729-213140.xlsx"
     generated.write_bytes(b"template")

--- a/CoupaTurboDownloader/tests/test_python_portable_build.py
+++ b/CoupaTurboDownloader/tests/test_python_portable_build.py
@@ -31,13 +31,16 @@ def test_portable_launcher_uses_official_pythonw_and_manual_updates(monkeypatch,
 
     portable._write_launchers()
 
-    launcher = (bundle / "Start-CoupaTurbo.cmd").read_text(encoding="ascii")
+    launcher = (bundle / "Start-ContractDownloader.cmd").read_text(encoding="ascii")
     python_launcher = (app / "launcher.py").read_text(encoding="utf-8")
-    metadata = json.loads((bundle / "portable-python.json").read_text(encoding="utf-8"))
+    metadata = json.loads((bundle / "contract-downloader.json").read_text(encoding="utf-8"))
     assert "COUPA_PYTHON_PORTABLE=1" in launcher
     assert "Unblock-File" in launcher
     assert "runtime\\pythonw.exe" in launcher
+    assert "Contract Downloader" in launcher
     assert "startup.log" in launcher
+    assert (bundle / "LEIA-ME.txt").is_file()
+    assert (bundle / "INSTRUCOES_CONTRACT_DOWNLOADER.md").is_file()
     assert "runpy.run_path" in python_launcher
     assert metadata["automatic_update_check_default"] is False
     assert metadata["manual_updates"] is True

--- a/CoupaTurboDownloader/tests/test_updater.py
+++ b/CoupaTurboDownloader/tests/test_updater.py
@@ -7,12 +7,12 @@ from src.engine import updater
 
 
 def _portable_runtime(tmp_path: Path, monkeypatch) -> Path:
-    root = tmp_path / "CoupaTurboDownloader-python-portable"
+    root = tmp_path / "ContractDownloader-python-portable"
     runtime = root / "runtime"
     runtime.mkdir(parents=True)
     executable = runtime / "pythonw.exe"
     executable.touch()
-    (root / "portable-python.json").write_text(json.dumps({"format": 1}), encoding="utf-8")
+    (root / "contract-downloader.json").write_text(json.dumps({"format": 1}), encoding="utf-8")
     monkeypatch.setenv("COUPA_PYTHON_PORTABLE", "1")
     monkeypatch.setattr(sys, "executable", str(executable))
     monkeypatch.setattr(sys, "platform", "win32")
@@ -22,20 +22,20 @@ def _portable_runtime(tmp_path: Path, monkeypatch) -> Path:
 def test_python_portable_selects_matching_release_asset(tmp_path, monkeypatch):
     _portable_runtime(tmp_path, monkeypatch)
     assets = [
-        {"name": "CoupaTurboDownloader-windows-x64.zip"},
-        {"name": "CoupaTurboDownloader-windows-python-portable-x64.zip"},
+        {"name": "ContractDownloader-windows-x64.zip"},
+        {"name": "ContractDownloader-windows-python-portable-x64.zip"},
     ]
 
     selected = updater._find_platform_asset(assets)
 
-    assert selected["name"] == "CoupaTurboDownloader-windows-python-portable-x64.zip"
+    assert selected["name"] == "ContractDownloader-windows-python-portable-x64.zip"
 
 
 def test_python_portable_rejects_release_without_matching_edition(tmp_path, monkeypatch):
     _portable_runtime(tmp_path, monkeypatch)
 
     selected = updater._find_platform_asset([
-        {"name": "CoupaTurboDownloader-windows-x64.zip"},
+        {"name": "ContractDownloader-windows-x64.zip"},
     ])
 
     assert selected is None
@@ -45,13 +45,13 @@ def test_regular_windows_build_does_not_select_python_portable(monkeypatch):
     monkeypatch.delenv("COUPA_PYTHON_PORTABLE", raising=False)
     monkeypatch.setattr(sys, "platform", "win32")
     assets = [
-        {"name": "CoupaTurboDownloader-windows-python-portable-x64.zip"},
-        {"name": "CoupaTurboDownloader-windows-x64.zip"},
+        {"name": "ContractDownloader-windows-python-portable-x64.zip"},
+        {"name": "ContractDownloader-windows-x64.zip"},
     ]
 
     selected = updater._find_platform_asset(assets)
 
-    assert selected["name"] == "CoupaTurboDownloader-windows-x64.zip"
+    assert selected["name"] == "ContractDownloader-windows-x64.zip"
 
 
 def test_prepare_update_returns_portable_bundle_root(tmp_path, monkeypatch):
@@ -59,15 +59,15 @@ def test_prepare_update_returns_portable_bundle_root(tmp_path, monkeypatch):
     package = tmp_path / "update.zip"
     with zipfile.ZipFile(package, "w") as archive:
         archive.writestr(
-            "CoupaTurboDownloader-python-portable/portable-python.json",
+            "ContractDownloader-python-portable/contract-downloader.json",
             '{"format": 1}',
         )
         archive.writestr(
-            "CoupaTurboDownloader-python-portable/Start-CoupaTurbo.cmd",
+            "ContractDownloader-python-portable/Start-ContractDownloader.cmd",
             "@echo off\n",
         )
 
     payload = Path(updater.prepare_update(str(package)))
 
-    assert payload.name == "CoupaTurboDownloader-python-portable"
-    assert (payload / "portable-python.json").is_file()
+    assert payload.name == "ContractDownloader-python-portable"
+    assert (payload / "contract-downloader.json").is_file()


### PR DESCRIPTION
## Nome e identidade
- Renomeia o aplicativo, executáveis, bundles, launchers e artifacts para Contract Downloader.
- Atualiza título, marca, diagnóstico, templates e textos da UI.
- Mantém identificadores internos Python e a pasta de dados existente para compatibilidade.

## Instruções
- Adiciona INSTRUCOES_CONTRACT_DOWNLOADER.md e LEIA-ME.txt dentro do bundle.
- Explica extração, caminho curto no Windows, inicialização, login, retry e suporte.

## Validação
- 131 testes aprovados
- JavaScript/Python validados

## Summary by Sourcery

Rename the product to Contract Downloader across executables, bundles, UI texts, and update logic, while keeping Python internals compatible.

New Features:
- Add portable Windows distribution metadata and instructions specific to Contract Downloader, including bundled LEIA-ME and INSTRUCOES_CONTRACT_DOWNLOADER files.
- Introduce macOS-specific launcher script and PyInstaller spec for the Contract Downloader application bundle.

Enhancements:
- Adjust updater logic and diagnostics to recognize both legacy and new portable markers and asset names, ensuring seamless updates for the renamed product.
- Update template generation paths and labels to use the new Contract Downloader workspace location under Documents.

CI:
- Update GitHub Actions build and release workflow artifact names and paths to use the Contract Downloader branding for Windows, Python portable, and macOS packages.

Tests:
- Update and extend tests for portable builds, updater asset selection, and GUI API behavior to reflect the new Contract Downloader naming and bundled instruction files.