### PR TITLE
feat: revisão UX + mapeamento de colunas

### DIFF
--- a/ContractDownloader/docs/INSTRUCOES_CONTRACT_DOWNLOADER.md
+++ b/ContractDownloader/docs/INSTRUCOES_CONTRACT_DOWNLOADER.md
@@ -32,11 +32,13 @@ Quando solicitado:
 
 1. Escolha o arquivo Excel ou CSV de input.
 2. Valide o arquivo.
-3. Escolha a estrutura de pastas.
-4. Escolha a pasta de destino.
+   - Se as colunas obrigatórias (PO e Fornecedor) não forem encontradas, o aplicativo mostra **Map the file columns**: selecione qual coluna contém o número da PO e qual contém o fornecedor.
+   - Erros são agrupados por tipo (linhas vazias, POs duplicadas, caracteres estranhos). Use o botão **Fix** de cada grupo para corrigir automaticamente, ou **Open file to fix** para editar manualmente.
+3. Escolha a estrutura de pastas — **Fornecedor** é sempre o primeiro nível e a **PO** o último. Use os botões ×/+ para ativar ou desativar níveis intermediários.
+4. Revise a árvore de pastas e escolha a pasta de destino.
 5. Revise as informações e clique em **Start download**.
 
-O arquivo original de input é preservado durante a execução.
+O arquivo original de input é preservado durante a execução. Inputs de execuções anteriores são protegidos (somente leitura) e, se reutilizados, uma cópia de trabalho é criada para a nova execução.
 
 ## 5. Corrigir uma PO com erro
 

--- a/ContractDownloader/process_all_pos.py
+++ b/ContractDownloader/process_all_pos.py
@@ -211,31 +211,51 @@ def _extract_hierarchy_columns(
         if str(c).strip() == "<|>":
             sep_col = c
             break
-    if sep_col is None:
+
+    cols = [str(c) for c in df.columns]
+    if requested_order is not None and not requested_order:
+        # The GUI explicitly disabled every optional level: only Supplier is used.
+        return [], False
+    if sep_col is not None:
+        sep_idx = cols.index(str(sep_col))
+        hierarchy_cols = cols[sep_idx + 1 :]
+    elif requested_order is not None:
+        # Non-standard inputs without the <|> separator: every column is a
+        # hierarchy candidate; the GUI decides which ones to enable.
+        hierarchy_cols = cols
+    else:
+        # Plain CLI input without <|> and without an explicit order keeps the
+        # classic behavior: only the supplier folder level is created.
         return [], False
 
-    cols = list(df.columns)
-    sep_idx = cols.index(sep_col)
-    hierarchy_cols = cols[sep_idx + 1 :]
     if requested_order:
-        requested = [str(column) for column in requested_order if str(column) in hierarchy_cols]
-        hierarchy_cols = requested + [column for column in hierarchy_cols if column not in requested]
+        # Explicit user order wins: these are exactly the columns the GUI
+        # enabled, in the chosen order (Supplier and PO are handled outside).
+        requested = [str(column) for column in requested_order if str(column) in cols]
+        if requested:
+            hierarchy_cols = requested
     if not hierarchy_cols:
         return [], False
 
+    # A column that is 100% empty in the input cannot drive folder creation.
+    # The GUI still reports it as a warning; the pipeline simply ignores it.
+    populated = []
     for col in hierarchy_cols:
         series = df[col].fillna("").astype(str).str.strip()
         series = series[(series != "") & (series.str.lower() != "nan")]
         if not series.empty:
-            return hierarchy_cols, True
-    return hierarchy_cols, False
+            populated.append(col)
+    if not populated:
+        return hierarchy_cols, False
+    return populated, True
 
 
 def _build_output_subdir(row: pd.Series, supplier: str, hierarchy_cols: list[str], has_hierarchy_data: bool) -> str:
+    # Supplier is always the first folder level; optional hierarchy columns
+    # come next. The PO itself is never a subdir part (it is the file level).
+    parts = [_clean_folder_part(supplier)]
     if has_hierarchy_data and hierarchy_cols:
-        parts = [_clean_folder_part(row.get(col, "")) for col in hierarchy_cols]
-    else:
-        parts = [str(supplier).strip() or "Unknown"]
+        parts.extend(_clean_folder_part(row.get(col, "")) for col in hierarchy_cols)
     return PurePosixPath(*parts).as_posix()
 
 
@@ -243,13 +263,18 @@ def build_output_subdir_map_from_csv(input_csv: str) -> dict[str, str]:
     if not input_csv or not os.path.exists(input_csv):
         return {}
 
+    from src.engine.input_schema import parse_mapping_env
+
     df = read_input_dataframe(input_csv)
+    mapping = parse_mapping_env() or {}
+    po_name = mapping.get("po") or "PO_NUMBER"
+    supplier_name = mapping.get("supplier") or "SUPPLIER"
     hierarchy_cols, has_hierarchy_data = _extract_hierarchy_columns(df)
     po_to_subdir: dict[str, str] = {}
 
     for _, row in df.iterrows():
-        po = str(row.get("PO_NUMBER", "")).strip()
-        supplier = str(row.get("SUPPLIER", "")).strip()
+        po = str(row.get(po_name, "")).strip()
+        supplier = str(row.get(supplier_name, "")).strip()
         if po and po.lower() != "nan" and supplier and supplier.lower() != "nan":
             po_to_subdir[po] = _build_output_subdir(row, supplier, hierarchy_cols, has_hierarchy_data)
     return po_to_subdir
@@ -383,16 +408,25 @@ def create_session_from_csv(
     input_csv: str,
     execution_type: str = "PROD",
     hierarchy_order: list[str] | None = None,
+    po_column: str | None = None,
+    supplier_column: str | None = None,
+    description: str | None = None,
 ) -> tuple[int, int]:
     cursor = db.conn.cursor()
     df = read_input_dataframe(input_csv)
     hierarchy_cols, has_hierarchy_data = _extract_hierarchy_columns(df, hierarchy_order)
-    session_id = db.create_session(os.path.basename(input_csv), execution_type=execution_type)
+    session_id = db.create_session(
+        os.path.basename(input_csv),
+        execution_type=execution_type,
+        description=description or None,
+    )
 
+    po_name = po_column or "PO_NUMBER"
+    supplier_name = supplier_column or "SUPPLIER"
     count = 0
     for _, row in df.iterrows():
-        po = str(row.get("PO_NUMBER", "")).strip()
-        company = str(row.get("SUPPLIER", "")).strip()
+        po = str(row.get(po_name, "")).strip()
+        company = str(row.get(supplier_name, "")).strip()
         if po and po.lower() != "nan" and company and company.lower() != "nan":
             output_subdir = _build_output_subdir(row, company, hierarchy_cols, has_hierarchy_data)
             cursor.execute(
@@ -741,11 +775,17 @@ async def main():
                 hierarchy_order = json.loads(os.environ["COUPA_HIERARCHY_ORDER"])
             except json.JSONDecodeError:
                 hierarchy_order = None
+        from src.engine.input_schema import parse_mapping_env
+        column_mapping = parse_mapping_env() or {}
+        run_description = os.environ.get("COUPA_RUN_DESCRIPTION") or None
         session_id, count = create_session_from_csv(
             db,
             INPUT_CSV,
             execution_type=run_type,
             hierarchy_order=hierarchy_order,
+            po_column=column_mapping.get("po"),
+            supplier_column=column_mapping.get("supplier"),
+            description=run_description,
         )
         print(f"[INFO] {count} POs imported and queued for processing.")
         print(f"[INFO] Session type: {run_type}")

--- a/ContractDownloader/scripts/gui_playwright_debug.py
+++ b/ContractDownloader/scripts/gui_playwright_debug.py
@@ -492,27 +492,30 @@ def run_probe(
             # Guardrail: the first journey step must remain visible and block progression without a file.
             steps.append("checked-next-without-file")
 
+            def complete_journey_to_review():
+                """Walk the New Run journey up to the review step (step 5)."""
+                page.click("#btn-next-input")
+                page.wait_for_selector("#validation-feedback:not([hidden])")
+                page.click("#btn-next-hierarchy")
+                page.click("#btn-next-destination")
+                page.click("#btn-choose-dir")
+                page.click("#btn-next-review")
+
             page.locator("#file-input").set_input_files(str(sample_csv))
             steps.append("selected-input-file")
             page.screenshot(path=str(run_dir / "02_file_selected.png"), full_page=True)
 
-            # Guardrail: Start over must reset the journey and re-enable input.
+            # Guardrail: Start over only exists at the final step and must
+            # reset the journey, re-enabling the input step.
+            complete_journey_to_review()
             page.click("#btn-start-over")
+            page.wait_for_selector("#dropzone", state="visible")
             steps.append("start-over-clicked")
             page.locator("#file-input").set_input_files(str(sample_csv))
             steps.append("re-selected-after-start-over")
-
-            page.click("#btn-next-input")
-            page.wait_for_selector("#validation-feedback:not([hidden])")
-            page.click("#btn-next-hierarchy")
-            page.click("#btn-next-destination")
-            page.click("#btn-choose-dir")
-            page.click("#btn-next-review")
+            complete_journey_to_review()
             page.click("#btn-start-run")
             steps.append("clicked-start")
-            if page.locator("#folder-confirm-modal").is_visible():
-                page.click("#btn-confirm-folder-run")
-                steps.append("confirmed-folder-structure")
 
             page.wait_for_selector("#screen-progress.active")
             page.wait_for_timeout(1500)

--- a/ContractDownloader/src/db/session_db.py
+++ b/ContractDownloader/src/db/session_db.py
@@ -106,6 +106,7 @@ class SessionDB:
             "input_file_blob": "BLOB",
             "input_file_sha256": "TEXT",
             "input_file_size": "INTEGER",
+            "description": "TEXT",
         }.items():
             if column not in sessions_existing:
                 cursor.execute(f"ALTER TABLE sessions ADD COLUMN {column} {definition}")
@@ -123,18 +124,28 @@ class SessionDB:
                 "ALTER TABLE po_downloads ADD COLUMN output_subdir TEXT"
             )
 
-    def create_session(self, input_file: str, execution_type: str = "PROD") -> int:
+    def create_session(self, input_file: str, execution_type: str = "PROD", description: Optional[str] = None) -> int:
         normalized_type = (execution_type or "PROD").strip().upper()
         if normalized_type not in {"PROD", "TEST"}:
             normalized_type = "PROD"
 
         cursor = self.conn.cursor()
         cursor.execute('''
-            INSERT INTO sessions (input_file, execution_type, status)
-            VALUES (?, ?, 'PENDING')
-        ''', (input_file, normalized_type))
+            INSERT INTO sessions (input_file, execution_type, status, description)
+            VALUES (?, ?, 'PENDING', ?)
+        ''', (input_file, normalized_type, description or None))
         self.conn.commit()
         return cursor.lastrowid
+
+    def update_session_description(self, session_id: int, description: Optional[str] = None) -> bool:
+        """Set the free-form run title/description used for audit context."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "UPDATE sessions SET description = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (description or None, session_id),
+        )
+        self.conn.commit()
+        return cursor.rowcount > 0
 
     def archive_session_input(self, session_id: int, source_path: str, archive_path: str) -> str:
         source = Path(source_path).expanduser().resolve()

--- a/ContractDownloader/src/engine/input_schema.py
+++ b/ContractDownloader/src/engine/input_schema.py
@@ -1,0 +1,97 @@
+"""Column schema helpers shared by the GUI and the canonical CLI pipeline.
+
+These functions are pure and deterministic: they normalize column names,
+detect the required PO/Supplier columns from a list of headers, and resolve
+an explicit user mapping on top of auto-detection.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+# Aliases accepted for the two mandatory fields, in detection priority order.
+PO_KEYS = ("ponumber", "po", "pedido", "purchaseordernumber", "ordernumber")
+SUPPLIER_KEYS = ("supplier", "fornecedor", "legalentity", "companycode", "empresa", "vendor")
+
+REQUIRED_FIELDS = ("po", "supplier")
+
+
+def normalize_column_name(column: Any) -> str:
+    """Normalize a header for alias comparison: lowercase, alnum only."""
+    return re.sub(r"[^a-z0-9]+", "", str(column or "").lower().strip())
+
+
+def detect_required_columns(columns: List[Any]) -> Dict[str, Optional[str]]:
+    """Return {'po': ..., 'supplier': ...} with detected header names.
+
+    Auto-detection uses the alias lists above. A header is matched by its
+    normalized name; the original display name is returned.
+    """
+    normalized = {normalize_column_name(column): str(column) for column in columns}
+    detected: Dict[str, Optional[str]] = {"po": None, "supplier": None}
+    for key in PO_KEYS:
+        if key in normalized:
+            detected["po"] = normalized[key]
+            break
+    for key in SUPPLIER_KEYS:
+        if key in normalized:
+            detected["supplier"] = normalized[key]
+            break
+    return detected
+
+
+def resolve_mapping(
+    columns: List[Any],
+    mapping: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Optional[str]]:
+    """Resolve an explicit mapping on top of auto-detection.
+
+    ``mapping`` may contain 'po' and/or 'supplier' keys whose values are
+    header names present in ``columns``. Auto-detection fills whatever the
+    mapping does not provide; an explicit mapping wins over detection when
+    both are available.
+    """
+    detected = detect_required_columns(columns)
+    resolved = dict(detected)
+    if not mapping:
+        return resolved
+
+    available = {normalize_column_name(column): str(column) for column in columns}
+    for field in REQUIRED_FIELDS:
+        value = mapping.get(field)
+        if not value:
+            continue
+        key = normalize_column_name(value)
+        if key in available:
+            resolved[field] = available[key]
+        elif str(value) in {str(c) for c in columns}:
+            resolved[field] = str(value)
+    return resolved
+
+
+def parse_mapping_env(environ: Optional[Dict[str, str]] = None) -> Optional[Dict[str, str]]:
+    """Read COUPA_COLUMN_MAPPING from the environment (used by the CLI worker)."""
+    env = environ if environ is not None else os.environ
+    raw = env.get("COUPA_COLUMN_MAPPING")
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    mapping = {}
+    for field in REQUIRED_FIELDS:
+        value = parsed.get(field)
+        if isinstance(value, str) and value.strip():
+            mapping[field] = value.strip()
+    return mapping or None
+
+
+def columns_of_dataframe(frame) -> List[Any]:
+    """Return the display names of a pandas DataFrame's columns."""
+    return [str(column) for column in frame.columns]

--- a/ContractDownloader/src/gui/api.py
+++ b/ContractDownloader/src/gui/api.py
@@ -109,6 +109,80 @@ class AppAPI:
         self.default_download_dir = root
         return root
 
+    # ------------------------------------------------------------------
+    # Column mapping persistence (per input file)
+    # ------------------------------------------------------------------
+    def _column_mappings_path(self):
+        return self._settings_path.parent / "column_mappings.json"
+
+    def _load_column_mappings(self) -> Dict[str, Dict[str, str]]:
+        try:
+            data = json.loads(self._column_mappings_path().read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (OSError, ValueError):
+            return {}
+
+    def _save_column_mappings(self, mappings: Dict[str, Dict[str, str]]) -> None:
+        try:
+            self._column_mappings_path().parent.mkdir(parents=True, exist_ok=True)
+            self._column_mappings_path().write_text(json.dumps(mappings, indent=2), encoding="utf-8")
+        except OSError:
+            pass
+
+    def _mapping_for(self, filepath: str) -> Dict[str, str]:
+        key = str(Path(filepath).expanduser().resolve())
+        stored = self._load_column_mappings().get(key, {})
+        return {k: v for k, v in stored.items() if v}
+
+    def get_input_columns(self, filepath: str) -> Dict[str, Any]:
+        """Return the input headers plus auto-detected PO/Supplier columns."""
+        from src.engine.input_schema import columns_of_dataframe, detect_required_columns
+
+        path = Path(filepath)
+        if not path.exists():
+            return {"success": False, "error": f"File not found: {filepath}"}
+        try:
+            if path.suffix.lower() in {".xlsx", ".xls"}:
+                frame = pd.read_excel(path, dtype=str, nrows=5)
+            else:
+                with open(path, encoding="utf-8-sig") as handle:
+                    sample = handle.read(4096)
+                sep = ";" if sample.count(";") > sample.count(",") else ","
+                frame = pd.read_csv(path, sep=sep, dtype=str, encoding="utf-8-sig", nrows=5)
+        except Exception as exc:
+            return {"success": False, "error": f"Could not read the input file: {exc}"}
+        columns = columns_of_dataframe(frame)
+        return {
+            "success": True,
+            "columns": columns,
+            "detected": detect_required_columns(columns),
+            "mapping": self._mapping_for(str(path)),
+        }
+
+    def map_input_columns(self, filepath: str, mapping: Dict[str, Any]) -> Dict[str, Any]:
+        """Store an explicit PO/Supplier column mapping and re-validate."""
+        from src.engine.input_schema import REQUIRED_FIELDS, resolve_mapping
+
+        path = Path(filepath)
+        if not path.exists():
+            return {"success": False, "error": f"File not found: {filepath}"}
+        columns = self.get_input_columns(str(path)).get("columns", [])
+        requested = {str(key).lower(): str(value or "").strip() for key, value in (mapping or {}).items()}
+        resolved = resolve_mapping(columns, requested)
+        missing = [field for field in REQUIRED_FIELDS if not resolved.get(field)]
+        if missing:
+            return {
+                "success": False,
+                "error": f"Mapping is incomplete. Required fields: {', '.join(REQUIRED_FIELDS)}.",
+                "missing": missing,
+            }
+        stored = self._load_column_mappings()
+        key = str(path.expanduser().resolve())
+        stored[key] = {"po": resolved["po"], "supplier": resolved["supplier"]}
+        self._save_column_mappings(stored)
+        validation = self.validate_input_file(str(path))
+        return {"success": True, "mapping": stored[key], **validation}
+
     def get_app_settings(self) -> Dict[str, Any]:
         settings = self._read_settings()
         settings["download_root"] = self.default_download_dir
@@ -944,19 +1018,20 @@ class AppAPI:
         }
 
     def validate_input_file(self, filepath: str) -> Dict[str, Any]:
-        """Validate a populated CSV file before importing.
+        """Validate a populated CSV/XLSX file before importing.
 
-        Checks:
-          - File exists and is readable
-          - Required columns present (PO_NUMBER or equivalent)
-          - Supplier/company column present
-          - No empty PO numbers
-          - No duplicate PO numbers
-
-        Returns a list of errors/warnings so the user can fix them in-place.
+        Errors are grouped by cause so the UI can offer a targeted fix per
+        group (remove blank rows, remove duplicate POs, clean invalid
+        characters) or open the file for assisted editing when no safe
+        automatic repair exists.
         """
         import re
         from pathlib import Path
+        from src.engine.input_schema import (
+            columns_of_dataframe,
+            normalize_column_name,
+            resolve_mapping,
+        )
 
         path = Path(filepath)
         if not path.exists():
@@ -987,47 +1062,63 @@ class AppAPI:
         except Exception as e:
             return {"valid": False, "errors": [f"Failed to parse input file: {e}"], "warnings": []}
 
+        mapping = resolve_mapping(columns_of_dataframe(df), self._mapping_for(str(path)))
+
         hierarchy_columns = []
+        empty_hierarchy_columns = []
         sep_column = next((column for column in df.columns if str(column).strip() == "<|>"), None)
         if sep_column is not None:
             hierarchy_columns = [str(column) for column in list(df.columns)[list(df.columns).index(sep_column) + 1:]]
+        else:
+            # Non-standard inputs without the <|> separator: every column
+            # except the mapped PO/Supplier is a hierarchy candidate.
+            excluded = {mapping.get("po"), mapping.get("supplier")}
+            hierarchy_columns = [str(column) for column in df.columns if str(column) not in excluded]
+        for column in hierarchy_columns:
+            series = df[column].fillna("").astype(str).str.strip()
+            series = series[(series != "") & (series.str.lower() != "nan")]
+            if series.empty:
+                empty_hierarchy_columns.append(str(column))
+
+        mapping = resolve_mapping(columns_of_dataframe(df), self._mapping_for(str(path)))
 
         errors: list[str] = []
         warnings: list[str] = []
         fixes: list[Dict[str, Any]] = []
+        groups: list[Dict[str, Any]] = []
         valid_count = 0
 
-        # Normalize column names for matching
-        def norm(col):
-            return re.sub(r"[^a-z0-9]+", "", str(col).lower().strip())
-
-        norm_cols = {norm(c): c for c in df.columns}
-
         # Required: PO column
-        po_keys = ["ponumber", "po", "pedido"]
-        po_col = None
-        for key in po_keys:
-            if key in norm_cols:
-                po_col = norm_cols[key]
-                break
+        po_col = mapping.get("po")
         if not po_col:
             errors.append(
                 f"Missing PO Number column. Expected one of: PO_NUMBER, PO, Pedido. "
                 f"Found: {list(df.columns)}"
             )
+            groups.append({
+                "id": "missing_po_column",
+                "severity": "error",
+                "title": "Missing PO Number column",
+                "count": 1,
+                "fixable": False,
+                "mapping": True,
+            })
 
         # Required: company/supplier column
-        company_keys = ["legalentity", "companycode", "empresa", "supplier"]
-        company_col = None
-        for key in company_keys:
-            if key in norm_cols:
-                company_col = norm_cols[key]
-                break
+        company_col = mapping.get("supplier")
         if not company_col:
             errors.append(
                 f"Missing Supplier/Company column. Expected one of: SUPPLIER, LegalEntity, CompanyCode, Empresa. "
                 f"Found: {list(df.columns)}"
             )
+            groups.append({
+                "id": "missing_supplier_column",
+                "severity": "error",
+                "title": "Missing Supplier/Company column",
+                "count": 1,
+                "fixable": False,
+                "mapping": True,
+            })
 
         if not errors:
             # Validate rows. Empty required values are errors because the user
@@ -1050,8 +1141,27 @@ class AppAPI:
                     "count": len(blank_rows),
                     "description": f"Remove {len(blank_rows)} completely blank row(s)",
                 })
+                groups.append({
+                    "id": "blank_rows",
+                    "severity": "error",
+                    "title": "Blank rows",
+                    "count": len(blank_rows),
+                    "rows": blank_rows[:10],
+                    "fix_action": "remove_blank_rows",
+                    "fixable": True,
+                    "message": f"Row(s) completely empty: {blank_rows[:10]}",
+                })
             if partial_rows:
                 errors.append(f"Missing PO Number or Supplier on row(s): {partial_rows[:10]}")
+                groups.append({
+                    "id": "partial_rows",
+                    "severity": "error",
+                    "title": "Rows with missing PO or Supplier",
+                    "count": len(partial_rows),
+                    "rows": partial_rows[:10],
+                    "fixable": False,
+                    "message": f"Row(s) without PO Number or Supplier: {partial_rows[:10]}",
+                })
 
             clean = df.loc[~empty_mask].copy()
             duplicates = clean[clean.duplicated(subset=[po_col], keep=False)]
@@ -1063,6 +1173,41 @@ class AppAPI:
                     "count": int(duplicates[po_col].nunique()),
                     "description": "Keep the first row for each duplicated PO Number",
                 })
+                groups.append({
+                    "id": "duplicate_pos",
+                    "severity": "error",
+                    "title": "Duplicate PO numbers",
+                    "count": int(duplicates[po_col].nunique()),
+                    "rows": dup_pos,
+                    "fix_action": "remove_duplicate_pos",
+                    "fixable": True,
+                    "message": f"PO(s) repeated in the file: {dup_pos}",
+                })
+
+            # Invalid characters in the PO column (safe automatic cleanup).
+            char_pattern = re.compile(r"[^A-Za-z0-9_\-]")
+            dirty_pos = []
+            for value in clean[po_col].astype(str):
+                stripped = value.strip()
+                if stripped and char_pattern.search(stripped):
+                    dirty_pos.append(value)
+            if dirty_pos:
+                errors.append(f"PO Number(s) with unusual characters: {dirty_pos[:5]}")
+                fixes.append({
+                    "action": "clean_invalid_chars",
+                    "count": len(dirty_pos),
+                    "description": f"Remove unusual characters from {len(dirty_pos)} PO Number(s)",
+                })
+                groups.append({
+                    "id": "invalid_chars",
+                    "severity": "error",
+                    "title": "PO numbers with unusual characters",
+                    "count": len(dirty_pos),
+                    "rows": dirty_pos[:10],
+                    "fix_action": "clean_invalid_chars",
+                    "fixable": True,
+                    "message": "PO values contain characters outside letters, digits, '-' and '_'.",
+                })
 
             invalid_pos: list[str] = []
             for value in clean[po_col].astype(str):
@@ -1073,6 +1218,15 @@ class AppAPI:
                     f"{len(invalid_pos)} PO(s) have an unusual format (expected PO/PM prefix or digits): "
                     f"{invalid_pos[:5]}"
                 )
+                groups.append({
+                    "id": "unusual_format",
+                    "severity": "warning",
+                    "title": "PO numbers with an unusual format",
+                    "count": len(invalid_pos),
+                    "rows": invalid_pos[:10],
+                    "fixable": False,
+                    "message": "Expected values starting with PO/PM or only digits. Review these values in the file.",
+                })
 
             valid_count = len(clean.drop_duplicates(subset=[po_col]))
             if valid_count == 0:
@@ -1082,9 +1236,12 @@ class AppAPI:
             "valid": len(errors) == 0,
             "errors": errors,
             "warnings": warnings,
+            "groups": groups,
             "total_rows": len(df),
             "valid_po_count": valid_count if not errors else 0,
             "hierarchy_columns": hierarchy_columns,
+            "empty_hierarchy_columns": empty_hierarchy_columns,
+            "mapping": mapping,
             "fixes": fixes,
             "file_state": file_state,
         }
@@ -1099,7 +1256,7 @@ class AppAPI:
             return {"success": False, "error": "Save and close the input file before applying repairs."}
 
         actions = set(actions or [])
-        if not actions.intersection({"remove_blank_rows", "remove_duplicate_pos"}):
+        if not actions.intersection({"remove_blank_rows", "remove_duplicate_pos", "clean_invalid_chars"}):
             return {"success": False, "error": "No supported repair was selected."}
 
         if path.suffix.lower() == ".xls":
@@ -1110,10 +1267,17 @@ class AppAPI:
         shutil.copy2(path, backup)
         removed_blank = 0
         removed_duplicates = 0
+        cleaned_chars = 0
 
         def norm(column: Any) -> str:
             import re
             return re.sub(r"[^a-z0-9]+", "", str(column).lower().strip())
+
+        import re
+        char_pattern = re.compile(r"[^A-Za-z0-9_\-]")
+
+        def clean_value(value: str) -> str:
+            return char_pattern.sub("", value) if char_pattern.search(value) else value
 
         if path.suffix.lower() in {".xlsx", ".xlsm"}:
             from openpyxl import load_workbook
@@ -1135,7 +1299,13 @@ class AppAPI:
                     removed_blank += 1
                     continue
                 po_value = str(sheet.cell(row_number, po_column).value or "").strip()
-                if po_value and "remove_duplicate_pos" in actions:
+                if not po_value:
+                    continue
+                if "clean_invalid_chars" in actions and char_pattern.search(po_value):
+                    sheet.cell(row_number, po_column).value = clean_value(po_value)
+                    cleaned_chars += 1
+                    po_value = clean_value(po_value)
+                if "remove_duplicate_pos" in actions:
                     if po_value in seen_pos:
                         rows_to_remove.add(row_number)
                         removed_duplicates += 1
@@ -1160,6 +1330,10 @@ class AppAPI:
             if "remove_blank_rows" in actions:
                 removed_blank = int(blank_mask.sum())
                 frame = frame.loc[~blank_mask]
+            if "clean_invalid_chars" in actions:
+                mask = frame[po_column].fillna("").astype(str).str.strip().str.contains(char_pattern, regex=True)
+                frame.loc[mask, po_column] = frame.loc[mask, po_column].astype(str).map(clean_value)
+                cleaned_chars = int(mask.sum())
             if "remove_duplicate_pos" in actions:
                 duplicate_mask = frame.duplicated(subset=[po_column], keep="first")
                 removed_duplicates = int(duplicate_mask.sum())
@@ -1171,11 +1345,13 @@ class AppAPI:
             "backup_path": str(backup),
             "removed_blank_rows": removed_blank,
             "removed_duplicate_rows": removed_duplicates,
+            "cleaned_invalid_chars": cleaned_chars,
             "message": "Safe repairs applied. The original file was backed up.",
         }
 
     def import_file(self, filepath: str) -> Dict[str, Any]:
         import re
+        from src.engine.input_schema import columns_of_dataframe, resolve_mapping
         try:
             if not os.path.exists(filepath):
                 return {'success': False, 'error': f"File not found: {filepath}"}
@@ -1203,47 +1379,34 @@ class AppAPI:
                 text = text.strip('._')
                 return text or 'Unknown'
 
-            def extract_hierarchy_columns(frame: pd.DataFrame) -> tuple[list[str], bool]:
+            def extract_hierarchy_columns(frame: pd.DataFrame, exclude: set[str]) -> tuple[list[str], bool]:
                 sep_col = None
                 for c in frame.columns:
                     if str(c).strip() == '<|>':
                         sep_col = c
                         break
-                if sep_col is None:
-                    return [], False
 
-                cols = list(frame.columns)
-                hierarchy_cols = cols[cols.index(sep_col) + 1:]
+                cols = [str(c) for c in frame.columns]
+                if sep_col is not None:
+                    hierarchy_cols = cols[cols.index(str(sep_col)) + 1:]
+                else:
+                    # Non-standard inputs: all columns except PO/Supplier.
+                    hierarchy_cols = [c for c in cols if c not in exclude]
                 if not hierarchy_cols:
                     return [], False
 
+                populated = []
                 for col in hierarchy_cols:
                     series = frame[col].fillna('').astype(str).str.strip()
                     series = series[(series != '') & (series.str.lower() != 'nan')]
                     if not series.empty:
-                        return hierarchy_cols, True
-                return hierarchy_cols, False
+                        populated.append(col)
+                return hierarchy_cols, bool(populated)
 
-            hierarchy_cols, has_hierarchy_data = extract_hierarchy_columns(df)
-
-            def norm(col):
-                return re.sub(r'[^a-z0-9]+', '', str(col).lower().strip())
-            norm_cols = {norm(col): col for col in df.columns}
-
-            po_keys = ['ponumber', 'po', 'pedido']
-            company_keys = ['legalentity', 'companycode', 'empresa', 'supplier']
-
-            po_col = None
-            for key in po_keys:
-                if key in norm_cols:
-                    po_col = norm_cols[key]
-                    break
-
-            company_col = None
-            for key in company_keys:
-                if key in norm_cols:
-                    company_col = norm_cols[key]
-                    break
+            mapping = resolve_mapping(columns_of_dataframe(df), self._mapping_for(filepath))
+            po_col = mapping.get('po')
+            company_col = mapping.get('supplier')
+            hierarchy_cols, has_hierarchy_data = extract_hierarchy_columns(df, {po_col, company_col})
 
             if not po_col:
                 return {'success': False, 'error': f"Could not find PO Number column. Found columns: {list(df.columns)}"}
@@ -1261,11 +1424,12 @@ class AppAPI:
                 po_val = str(row[po_col]).strip()
                 company_val = str(row[company_col]).strip()
                 if po_val and po_val.lower() != 'nan' and company_val and company_val.lower() != 'nan':
+                    # Supplier is always the first folder level; optional
+                    # hierarchy columns come next (PO stays at the file level).
+                    parts = [clean_folder_part(company_val)]
                     if has_hierarchy_data and hierarchy_cols:
-                        parts = [clean_folder_part(row.get(col, '')) for col in hierarchy_cols]
-                        output_subdir = PurePosixPath(*parts).as_posix()
-                    else:
-                        output_subdir = company_val
+                        parts.extend(clean_folder_part(row.get(col, '')) for col in hierarchy_cols)
+                    output_subdir = PurePosixPath(*parts).as_posix()
 
                     self.db.add_po(PODownload(
                         session_id=session_id,

--- a/ContractDownloader/src/gui/cli_supervisor.py
+++ b/ContractDownloader/src/gui/cli_supervisor.py
@@ -76,6 +76,7 @@ class CliProcessSupervisor:
                 "input_file_blob": "BLOB",
                 "input_file_sha256": "TEXT",
                 "input_file_size": "INTEGER",
+                "description": "TEXT",
             }.items():
                 try:
                     conn.execute(f"ALTER TABLE sessions ADD COLUMN {column} {definition}")
@@ -241,6 +242,43 @@ class CliProcessSupervisor:
             "type": "Success" if return_code == 0 else "Error",
             "message": "Download pipeline finished." if return_code == 0 else f"Download pipeline exited with code {return_code}.",
         })
+        self._protect_archived_inputs()
+
+    @staticmethod
+    def _set_file_readonly(path: Path, readonly: bool = True) -> None:
+        """Toggle the OS read-only attribute on a file (best effort)."""
+        try:
+            if readonly:
+                os.chmod(path, 0o444)
+            else:
+                os.chmod(path, 0o644)
+        except OSError:
+            pass
+
+    def _protect_archived_inputs(self) -> None:
+        """Make archived inputs read-only after a run finishes so they stay an
+        immutable audit snapshot. Explicit retries remove the protection
+        temporarily and re-apply it afterwards."""
+        session_id = self.session_id
+        if not session_id:
+            return
+        context = self._session_context(session_id)
+        input_path = context.get("input_path") or ""
+        if input_path and Path(input_path).name.startswith(("input_source_", "input_restored_")):
+            self._set_file_readonly(Path(input_path), True)
+
+    def set_run_description(self, session_id: int, description: str) -> dict[str, Any]:
+        """Store the free-form run title/description used as audit context."""
+        try:
+            with self._connect() as conn:
+                conn.execute(
+                    "UPDATE sessions SET description = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (str(description or "").strip() or None, int(session_id)),
+                )
+                conn.commit()
+            return {"success": True, "session_id": int(session_id)}
+        except (sqlite3.Error, ValueError) as exc:
+            return {"success": False, "error": str(exc)}
 
     def _command(
         self,
@@ -320,6 +358,8 @@ class CliProcessSupervisor:
         retry_attempts: Optional[int] = None,
         msg_processing: str = "convert_extract",
         deduplicate_files: bool = True,
+        description: Optional[str] = None,
+        column_mapping: Optional[dict[str, str]] = None,
     ) -> dict[str, Any]:
         with self._lock:
             if self.process and self.process.poll() is None:
@@ -346,8 +386,12 @@ class CliProcessSupervisor:
 
             env = os.environ.copy()
             env["INPUT_CSV"] = self.input_path
-            if hierarchy_order:
+            if hierarchy_order is not None:
                 env["COUPA_HIERARCHY_ORDER"] = json.dumps(hierarchy_order)
+            if description:
+                env["COUPA_RUN_DESCRIPTION"] = str(description).strip()
+            if column_mapping:
+                env["COUPA_COLUMN_MAPPING"] = json.dumps(column_mapping)
             env["COUPA_RETRY_ATTEMPTS"] = str(max(1, min(3, int(retry_attempts or 1))))
             env["COUPA_MSG_PROCESSING"] = msg_processing if msg_processing in {"disabled", "convert", "convert_extract"} else "convert_extract"
             env["COUPA_DEDUPLICATE_FILES"] = "1" if deduplicate_files else "0"
@@ -846,6 +890,11 @@ class CliProcessSupervisor:
                 backup = path.with_name(f"{path.stem}.before_retry_{time.strftime('%Y%m%d-%H%M%S')}{path.suffix}")
                 shutil.copy2(path, backup)
                 backups.append((path, backup))
+            # The archived input is read-only between runs; an explicit retry
+            # is the only flow allowed to update it, so lift the protection
+            # for the duration of the edit and re-apply it afterwards.
+            for path in paths:
+                self._set_file_readonly(path, False)
             for path in paths:
                 self._replace_po_in_file(path, str(attempt["original_po_number"]), str(attempt["edited_po_number"]), note)
             if archive.exists():
@@ -856,6 +905,7 @@ class CliProcessSupervisor:
                         (str(archive), data, hashlib.sha256(data).hexdigest(), len(data), int(attempt["session_id"])),
                     )
                     conn.commit()
+                self._set_file_readonly(archive, True)
             return {"success": True, "paths": [str(path) for path in paths], "note": note}
         except (OSError, ValueError, sqlite3.Error) as exc:
             for path, backup in locals().get("backups", []):

--- a/ContractDownloader/src/gui/web/app.js
+++ b/ContractDownloader/src/gui/web/app.js
@@ -11,6 +11,8 @@ document.addEventListener("DOMContentLoaded", () => {
     let validatedFingerprint = null;
     let selectedFileValidated = false;
     let hierarchyOrder = [];
+    let disabledHierarchyColumns = [];
+    let mappingColumns = [];
     let draggedHierarchyItem = null;
     let runInProgress = false;
     let pendingUpdate = null;
@@ -22,14 +24,14 @@ document.addEventListener("DOMContentLoaded", () => {
             1: ["Choose your input", "Start with a completed CSV or Excel file, or create a new template."],
             2: ["Validate your input", "Check the file before configuring the download."],
             3: ["Arrange folder hierarchy", "Choose the order used to create destination folders."],
-            4: ["Choose the save location", "Select where this run should store its attachments."],
+            4: ["Confirm structure and destination", "Review the folder tree, then choose where the run saves files."],
             5: ["Review and start", "Confirm the settings, then start the download."],
         },
         "pt-BR": {
             1: ["Escolha o input", "Comece com um arquivo CSV ou Excel preenchido, ou crie um novo template."],
             2: ["Valide o input", "Verifique o arquivo antes de configurar o download."],
             3: ["Organize a hierarquia", "Escolha a ordem usada para criar as pastas de destino."],
-            4: ["Escolha o local de salvamento", "Selecione onde esta execução deve salvar os anexos."],
+            4: ["Confirme a estrutura e o destino", "Revise a árvore de pastas e escolha onde a execução salvará os arquivos."],
             5: ["Revise e inicie", "Confirme as configurações e inicie o download."],
         },
     };
@@ -103,6 +105,17 @@ document.addEventListener("DOMContentLoaded", () => {
         setMany("#speed-note, #eta-note", pt ? ["POs concluídas recentemente", "Atualizado pela velocidade recente"] : ["Recent completed POs", "Updates with recent speed"]);
         setMany("#btn-back-new, #btn-pause-resume, #btn-stop-session, #btn-clear-log", pt ? ["Nova execução", "Pausar", "Parar execução", "Limpar"] : ["New run", "Pause", "Stop run", "Clear"]);
         setMany("#screen-history .intro-block .eyebrow, #screen-history .intro-block h2", pt ? ["TRILHA DE AUDITORIA", "Histórico de execuções"] : ["AUDIT TRAIL", "Run history"]);
+        setMany("#active-run-banner strong", [pt ? "Uma baixa já está em andamento." : "A download is already running."]);
+        setMany("#active-run-banner span", [pt ? "Volte para Execução ativa para acompanhar." : "Return to Active run to monitor it."]);
+        setMany("#btn-go-active-run", [pt ? "Ver execução ativa" : "View active run"]);
+        setMany("#mapping-title, #mapping-subtitle", pt ? ["Mapeie as colunas do arquivo", "As colunas obrigatórias não foram encontradas automaticamente. Informe quais colunas contêm o número da PO e o fornecedor."] : ["Map the file columns", "The required columns were not found automatically. Tell the app which columns hold the PO number and the supplier."]);
+        setMany("#btn-apply-mapping", [pt ? "Aplicar mapeamento e validar" : "Apply mapping and validate"]);
+        setMany("#column-mapping-card .mapping-fields label", pt ? ["Coluna de número da PO", "Coluna de fornecedor"] : ["PO number column", "Supplier column"]);
+        setMany("#hierarchy-disabled h4", [pt ? "Colunas desativadas" : "Disabled columns"]);
+        setMany("#hierarchy-disabled p", [pt ? "Estas colunas permanecem no input e no relatório final, mas não criam pastas." : "These columns stay in the input and in the final report, but do not create folders."]);
+        setMany("#run-description-input", [pt ? "Por que esta execução foi feita? Para quem?" : "Why was this run made? For whom?"]);
+        setMany("#btn-save-run-description", [pt ? "Salvar" : "Save"]);
+        setMany(".description-hint", [pt ? "Texto livre que aparece no histórico para explicar o objetivo da execução (solicitação, análise, solicitante)." : "Free text shown in history to explain this run's purpose (request, analysis, requester)."]);
         setMany("#screen-history .intro-block p:not(.eyebrow)", [pt ? "Revise resultados, erros por PO e relatórios." : "Review results, inspect PO-level errors, and export reports."]);
         setMany("#btn-refresh-history, #btn-clear-history", pt ? ["Atualizar", "Excluir todo o histórico"] : ["Refresh", "Delete all history"]);
         setMany("#history-list ~ *", []);
@@ -201,7 +214,7 @@ document.addEventListener("DOMContentLoaded", () => {
         lockMessage.hidden = true;
         lockMessage.innerText = "";
         if (target === 2 && selectedFilePath) $("#validation-filename").innerText = $("#selected-filename").innerText;
-        if (target === 4 && !locked) ensureDefaultDestination();
+        if (target === 4 && !locked) { renderDestinationPreview(); ensureDefaultDestination(); }
         if (target === 5 && !locked) renderJourneyReview();
     }
 
@@ -225,6 +238,12 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function showScreen(screenKey) {
+        // While a download is running the New Run journey must stay locked:
+        // the user can only watch Active run or browse history/settings.
+        if (screenKey === "new" && runInProgress) {
+            logToConsole("Warning", appSettings.language === "pt-BR" ? "A Nova Execução fica bloqueada enquanto uma baixa está ativa." : "New Run stays locked while a download is running.");
+            screenKey = "progress";
+        }
         Object.entries(screens).forEach(([key, screen]) => {
             const active = key === screenKey;
             screen.classList.toggle("active", active);
@@ -233,6 +252,8 @@ document.addEventListener("DOMContentLoaded", () => {
         });
         const titles = { new: t("prepare"), progress: t("activeRun"), history: t("history"), learn: t("learn"), settings: t("settings") };
         if ($("#page-title")) $("#page-title").innerText = titles[screenKey] || titles.new;
+        navButtons.new.disabled = runInProgress;
+        navButtons.new.title = runInProgress ? (appSettings.language === "pt-BR" ? "Bloqueado durante a execução" : "Locked while a run is active") : "";
         $("#active-run-banner").hidden = !(screenKey === "new" && runInProgress);
         if (screenKey === "new" && runInProgress) $("#btn-start-run").disabled = true;
         syncUpdateButton();
@@ -246,10 +267,10 @@ document.addEventListener("DOMContentLoaded", () => {
     $("#btn-refresh-history").addEventListener("click", loadHistory);
     document.addEventListener("keydown", (event) => {
         if (event.key !== "Escape") return;
-        const folderModal = $("#folder-confirm-modal");
         const detailsModal = $("#details-modal");
-        if (folderModal && !folderModal.hidden) {
-            $("#btn-cancel-folder-confirm").click();
+        const retryEditModalEl = $("#retry-edit-modal");
+        if (retryEditModalEl && !retryEditModalEl.hidden) {
+            closeRetryEditModal();
         } else if (detailsModal && !detailsModal.hidden) {
             detailsModal.hidden = true;
         }
@@ -329,7 +350,12 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         $("#btn-authenticate").classList.toggle("is-authenticated", state === "authenticated");
         const action = $("#btn-authenticate .auth-action");
-        if (action) action.innerText = state === "authenticated" ? (pt ? "Autenticado" : "Ready") : (state.startsWith("auth_") || state === "authenticating" ? (pt ? "Aguarde…" : "Please wait…") : (pt ? "Entrar" : "Sign in"));
+        if (action) {
+            // One state at a time: when already authenticated the status text
+            // is enough, so the redundant "Sign in/Entrar" action disappears.
+            action.style.display = state === "authenticated" ? "none" : "";
+            action.innerText = state === "authenticated" ? (pt ? "Autenticado" : "Ready") : (state.startsWith("auth_") || state === "authenticating" ? (pt ? "Aguarde…" : "Please wait…") : (pt ? "Entrar" : "Sign in"));
+        }
         $("#btn-authenticate").disabled = state.startsWith("auth_") || state === "authenticating";
     }
 
@@ -372,21 +398,54 @@ document.addEventListener("DOMContentLoaded", () => {
 
     function syncHierarchyLevels(list) {
         list.querySelectorAll("li[data-column]").forEach((item, index) => {
-            item.dataset.level = String(index + 1);
-            item.style.setProperty("--hierarchy-level", String(index));
+            item.dataset.level = String(index + 2);
+            item.style.setProperty("--hierarchy-level", String(index + 1));
             const level = item.querySelector(".hierarchy-level");
-            if (level) level.innerText = `${appSettings.language === "pt-BR" ? "Nível" : "Level"} ${index + 1}`;
+            if (level) level.innerText = `${appSettings.language === "pt-BR" ? "Nível" : "Level"} ${index + 2}`;
         });
     }
 
     function renderHierarchy() {
         const list = $("#folder-hierarchy");
-        if (!hierarchyOrder.length) {
-            list.innerHTML = '<li class="hierarchy-empty">No hierarchy columns detected.</li>';
+        const levelLabel = appSettings.language === "pt-BR" ? "Nível" : "Level";
+        const supplierLabel = appSettings.language === "pt-BR" ? "Fornecedor (sempre primeiro)" : "Supplier (always first)";
+        const poLabel = appSettings.language === "pt-BR" ? "PO (sempre último)" : "PO (always last)";
+        const disableLabel = appSettings.language === "pt-BR" ? "Desativar" : "Disable";
+        const enableLabel = appSettings.language === "pt-BR" ? "Ativar" : "Enable";
+        if (!hierarchyOrder.length && !disabledHierarchyColumns.length) {
+            list.innerHTML = '<li class="hierarchy-empty">Validate the input to load its folder levels.</li>';
+            $("#hierarchy-disabled").hidden = true;
             return;
         }
-        const levelLabel = appSettings.language === "pt-BR" ? "Nível" : "Level";
-        list.innerHTML = hierarchyOrder.map((column, index) => `<li draggable="false" data-column="${escapeHtml(column)}" data-level="${index + 1}" style="--hierarchy-level:${index}"><span class="hierarchy-branch" aria-hidden="true">└</span><span class="hierarchy-level">${levelLabel} ${index + 1}</span><span class="drag-handle" aria-hidden="true">☷</span><span>${escapeHtml(column)}</span></li>`).join("");
+        const items = [
+            `<li class="hierarchy-fixed" data-fixed="supplier"><span class="hierarchy-branch" aria-hidden="true">└</span><span class="hierarchy-level">${levelLabel} 1</span><span class="hierarchy-lock" aria-hidden="true">🔒</span><strong>${supplierLabel}</strong></li>`,
+            ...hierarchyOrder.map((column, index) => `<li draggable="true" data-column="${escapeHtml(column)}" data-level="${index + 2}" style="--hierarchy-level:${index + 1}"><span class="hierarchy-branch" aria-hidden="true">└</span><span class="hierarchy-level">${levelLabel} ${index + 2}</span><span class="drag-handle" aria-hidden="true">☷</span><span>${escapeHtml(column)}</span><button class="hierarchy-toggle" data-toggle-column="${escapeHtml(column)}" title="${disableLabel}" type="button">×</button></li>`),
+            `<li class="hierarchy-fixed" data-fixed="po"><span class="hierarchy-branch" aria-hidden="true">└</span><span class="hierarchy-level">${levelLabel} ${hierarchyOrder.length + 2}</span><span class="hierarchy-lock" aria-hidden="true">🔒</span><strong>${poLabel}</strong></li>`,
+        ];
+        list.innerHTML = items.join("");
+        list.querySelectorAll(".hierarchy-toggle[data-toggle-column]").forEach((button) => {
+            button.addEventListener("click", () => {
+                const column = button.dataset.toggleColumn;
+                hierarchyOrder = hierarchyOrder.filter((value) => value !== column);
+                disabledHierarchyColumns.push(column);
+                renderHierarchy();
+            });
+        });
+
+        // Disabled columns list (kept in the report, not used as folders).
+        const disabledBox = $("#hierarchy-disabled");
+        const disabledList = $("#hierarchy-disabled-list");
+        disabledBox.hidden = disabledHierarchyColumns.length === 0;
+        disabledList.innerHTML = disabledHierarchyColumns.map((column) => `<li><span>${escapeHtml(column)}</span><button class="hierarchy-toggle" data-reenable-column="${escapeHtml(column)}" title="${enableLabel}" type="button">+</button></li>`).join("");
+        disabledList.querySelectorAll(".hierarchy-toggle[data-reenable-column]").forEach((button) => {
+            button.addEventListener("click", () => {
+                const column = button.dataset.reenableColumn;
+                disabledHierarchyColumns = disabledHierarchyColumns.filter((value) => value !== column);
+                hierarchyOrder.push(column);
+                renderHierarchy();
+            });
+        });
+
         let pointerDrag = null;
         const finishHierarchyDrag = () => {
             const item = draggedHierarchyItem;
@@ -400,6 +459,7 @@ document.addEventListener("DOMContentLoaded", () => {
             hierarchyOrder = [...list.querySelectorAll("li[data-column]")].map((node) => node.dataset.column);
             syncHierarchyLevels(list);
             list.classList.remove("drag-active");
+            renderDestinationPreview();
         };
 
         const placeHierarchyPlaceholder = (clientY) => {
@@ -421,7 +481,7 @@ document.addEventListener("DOMContentLoaded", () => {
         // stuck or fail altogether.
         list.querySelectorAll("li[data-column]").forEach((item) => {
             item.addEventListener("pointerdown", (event) => {
-                if (event.button !== 0) return;
+                if (event.button !== 0 || event.target.closest(".hierarchy-toggle")) return;
                 pointerDrag = { item, pointerId: event.pointerId, startY: event.clientY, active: false };
                 try { item.setPointerCapture(event.pointerId); } catch (_) { /* best effort */ }
             });
@@ -452,11 +512,34 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     }
 
+    function renderDestinationPreview() {
+        const preview = $("#destination-preview");
+        if (!preview) return;
+        const directory = $("#download-dir").value || "Downloads/CoupaAttachments";
+        const parts = hierarchyOrder.length ? hierarchyOrder : [];
+        const lines = [`${directory}/`, "└── {Supplier}"];
+        parts.forEach((part) => { lines.push(`    └── {${escapeHtml(part)}}`); });
+        lines.push("        └── {PO}/");
+        preview.innerText = lines.join("\n");
+    }
+
+    function renderHierarchyWarnings(emptyColumns) {
+        const box = $("#hierarchy-warnings");
+        const columns = Array.isArray(emptyColumns) ? emptyColumns : [];
+        if (!columns.length) { box.hidden = true; box.innerHTML = ""; return; }
+        box.hidden = false;
+        box.innerHTML = columns.map((column) => `<div class="validation-warning">${appSettings.language === "pt-BR"
+            ? `A coluna “${escapeHtml(column)}” está 100% vazia no input e não será usada para criar pastas.`
+            : `The column “${escapeHtml(column)}” is completely empty in the input and will not be used to create folders.`}</div>`).join("");
+    }
+
     function setHierarchyColumns(columns) {
         const available = (columns || []).map(String);
         const kept = hierarchyOrder.filter((column) => available.includes(column));
         hierarchyOrder = kept.concat(available.filter((column) => !kept.includes(column)));
+        disabledHierarchyColumns = disabledHierarchyColumns.filter((column) => available.includes(column));
         renderHierarchy();
+        renderDestinationPreview();
     }
 
     function setFile(filePath, fileName, fileSize) {
@@ -535,14 +618,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
     async function startOver() {
         const pt = appSettings.language === "pt-BR";
+        if (runInProgress) return;
         const hasJourneyState = Boolean(selectedFilePath || generatedTemplatePath || journeyMaxStep > 1);
         if (!hasJourneyState) {
             clearFile();
             return;
         }
         const confirmed = confirm(pt
-            ? "Começar de novo? O template criado pelo aplicativo será excluído. Arquivos de input escolhidos por você serão preservados."
-            : "Start over? A template created by the application will be deleted. Input files chosen by you will be preserved.");
+            ? "Começar de novo? O estado desta preparação será apagado e uma nova execução será iniciada do zero. O histórico e os resultados de execuções concluídas serão preservados. Um template criado pelo aplicativo será excluído; arquivos de input escolhidos por você serão preservados."
+            : "Start over? This preparation state will be cleared and a new run will begin from scratch. History and results of completed runs are preserved. A template created by the app will be deleted; input files you chose are preserved.");
         if (!confirmed) return;
         if (hasApi("reset_new_run")) {
             const result = await api().reset_new_run(generatedTemplatePath || selectedFilePath || "");
@@ -553,6 +637,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         generatedTemplatePath = null;
         hierarchyOrder = [];
+        disabledHierarchyColumns = [];
         clearFile();
         $("#download-dir").value = "";
         await ensureDefaultDestination();
@@ -659,46 +744,130 @@ document.addEventListener("DOMContentLoaded", () => {
         fileMonitorInterval = setInterval(pollFileState, 800);
     }
 
-    function renderValidation(result) {
+    function renderMappingCard(columns, detected) {
+        const card = $("#column-mapping-card");
+        if (!card || !Array.isArray(columns) || !columns.length) { card.hidden = true; return; }
+        const poSelect = $("#mapping-po-select");
+        const supplierSelect = $("#mapping-supplier-select");
+        const options = (placeholder) => `<option value="">${placeholder}</option>` + columns.map((column) => `<option value="${escapeHtml(column)}">${escapeHtml(column)}</option>`).join("");
+        poSelect.innerHTML = options(appSettings.language === "pt-BR" ? "— selecione a coluna de PO —" : "— select the PO column —");
+        supplierSelect.innerHTML = options(appSettings.language === "pt-BR" ? "— selecione a coluna de fornecedor —" : "— select the supplier column —");
+        if (detected && detected.po) poSelect.value = detected.po;
+        if (detected && detected.supplier) supplierSelect.value = detected.supplier;
+        mappingColumns = columns;
+        card.hidden = false;
+    }
+
+    function hideMappingCard() {
+        const card = $("#column-mapping-card");
+        if (card) card.hidden = true;
+    }
+
+    async function applyColumnMapping() {
+        if (!selectedFilePath || !hasApi("map_input_columns")) return;
+        const mapping = {
+            po: $("#mapping-po-select").value,
+            supplier: $("#mapping-supplier-select").value,
+        };
+        if (!mapping.po || !mapping.supplier) {
+            logToConsole("Error", appSettings.language === "pt-BR" ? "Selecione as colunas de PO e fornecedor." : "Select the PO and supplier columns first.");
+            return;
+        }
+        const button = $("#btn-apply-mapping");
+        button.disabled = true;
+        const result = await api().map_input_columns(selectedFilePath, mapping);
+        button.disabled = false;
+        if (!result.success) {
+            logToConsole("Error", result.error || "Could not apply the column mapping.");
+            return;
+        }
+        logToConsole("Success", appSettings.language === "pt-BR" ? `Mapeamento aplicado: PO → ${result.mapping.po}, Fornecedor → ${result.mapping.supplier}.` : `Mapping applied: PO → ${result.mapping.po}, Supplier → ${result.mapping.supplier}.`);
+        renderValidation(result);
+    }
+
+    async function renderValidation(result) {
         const feedback = $("#validation-feedback");
         const errors = Array.isArray(result.errors) ? result.errors : [];
         const warnings = Array.isArray(result.warnings) ? result.warnings : [];
         const fixes = Array.isArray(result.fixes) ? result.fixes : [];
+        const groups = Array.isArray(result.groups) ? result.groups : [];
+        const mapping = result.mapping || {};
+        const pt = appSettings.language === "pt-BR";
         let html = "";
         setHierarchyColumns(result.hierarchy_columns || []);
-        if (result.valid) html += `<div class="validation-success">File is valid — ${result.valid_po_count || 0} PO(s) ready.</div>`;
-        else html += `<div class="validation-error-header">File needs correction (${errors.length} error${errors.length === 1 ? "" : "s"})</div>`;
+        renderHierarchyWarnings(result.empty_hierarchy_columns || []);
+        const needsMapping = groups.some((group) => group.mapping);
+        if (needsMapping) {
+            renderMappingCard(mappingColumns.length ? mappingColumns : (await getInputColumnsForMapping()));
+        } else {
+            hideMappingCard();
+        }
+        if (result.valid) html += `<div class="validation-success">${pt ? `Arquivo válido — ${result.valid_po_count || 0} PO(s) prontos.` : `File is valid — ${result.valid_po_count || 0} PO(s) ready.`}</div>`;
+        else html += `<div class="validation-error-header">${pt ? `O arquivo precisa de correção (${groups.length} grupo(s) de problema)` : `File needs correction (${groups.length} issue group(s))`}</div>`;
+        if (groups.length) {
+            html += `<div class="validation-dashboard">`;
+            groups.forEach((group) => {
+                const severityClass = group.severity === "warning" ? "validation-warning" : "validation-error";
+                html += `<div class="validation-group"><div class="validation-group-head ${severityClass}"><strong>${escapeHtml(group.title || group.id)}</strong><span>${group.count || 0}</span></div><p>${escapeHtml(group.message || "")}</p>`;
+                if (group.fixable && hasApi("repair_input_file")) {
+                    html += `<button class="btn btn-secondary btn-small btn-fix-group" data-fix="${escapeHtml(group.fix_action)}" type="button">${pt ? "Corrigir" : "Fix"}</button>`;
+                } else if (group.fixable === false && group.id !== "missing_po_column" && group.id !== "missing_supplier_column") {
+                    html += `<button class="btn btn-secondary btn-small btn-open-fix" type="button">${pt ? "Abrir arquivo para corrigir" : "Open file to fix"}</button>`;
+                }
+                html += `</div>`;
+            });
+            html += `</div>`;
+        }
         errors.forEach((error) => { html += `<div class="validation-error">${escapeHtml(error)}</div>`; });
         warnings.forEach((warning) => { html += `<div class="validation-warning">${escapeHtml(warning)}</div>`; });
-        fixes.forEach((fix) => { html += `<div class="validation-info">Suggested fix: ${escapeHtml(fix.description || fix.action)}</div>`; });
-        if (fixes.length && hasApi("repair_input_file")) {
-            html += `<button class="btn btn-secondary btn-small" id="btn-repair-file" type="button">Apply safe fixes and create backup</button>`;
-        }
+        fixes.forEach((fix) => { html += `<div class="validation-info">${pt ? "Correção sugerida:" : "Suggested fix:"} ${escapeHtml(fix.description || fix.action)}</div>`; });
         feedback.innerHTML = html;
-        const repairButton = $("#btn-repair-file");
-        if (repairButton) repairButton.addEventListener("click", async () => {
-            repairButton.disabled = true;
-            repairButton.innerText = "Applying fixes…";
-            const repaired = await api().repair_input_file(selectedFilePath, fixes.map((fix) => fix.action));
-            if (!repaired.success) {
-                logToConsole("Error", repaired.error || "Could not repair the file.");
-                repairButton.disabled = false;
-                repairButton.innerText = "Apply safe fixes and create backup";
-                return;
-            }
-            selectedFileValidated = false;
-            validatedFingerprint = null;
-            logToConsole("Success", `${repaired.message} Backup: ${repaired.backup_path}`);
-            feedback.innerHTML = `<div class="validation-success">${escapeHtml(repaired.message)} Revalidating…</div>`;
-            setTimeout(validateCurrentFile, 1000);
+        feedback.querySelectorAll(".btn-fix-group").forEach((button) => {
+            button.addEventListener("click", async () => {
+                button.disabled = true;
+                button.innerText = pt ? "Corrigindo…" : "Applying…";
+                const repaired = await api().repair_input_file(selectedFilePath, [button.dataset.fix]);
+                if (!repaired.success) {
+                    logToConsole("Error", repaired.error || "Could not repair the file.");
+                    button.disabled = false;
+                    button.innerText = pt ? "Corrigir" : "Fix";
+                    return;
+                }
+                selectedFileValidated = false;
+                validatedFingerprint = null;
+                logToConsole("Success", `${repaired.message} Backup: ${repaired.backup_path}`);
+                feedback.innerHTML = `<div class="validation-success">${escapeHtml(repaired.message)} ${pt ? "Revalidando…" : "Revalidating…"}</div>`;
+                setTimeout(validateCurrentFile, 1000);
+            });
+        });
+        feedback.querySelectorAll(".btn-open-fix").forEach((button) => {
+            button.addEventListener("click", async () => {
+                if (hasApi("open_input_path")) {
+                    const opened = await api().open_input_path(selectedFilePath);
+                    if (!opened.success) logToConsole("Error", opened.error || "Could not open the input file.");
+                }
+            });
         });
         feedback.hidden = false;
         selectedFileValidated = Boolean(result.valid);
         const state = result.file_state || {};
         validatedFingerprint = state.mtime_ns && state.size ? `${state.mtime_ns}:${state.size}` : null;
         $("#btn-next-hierarchy").disabled = !selectedFileValidated;
-        updateReadyState(result.valid ? "authenticated" : "unauthenticated", result.valid ? "Input validated" : "Input needs correction", result.valid ? "Ready to configure the download." : "Edit the same file and validate again.");
+        updateReadyState(result.valid ? "authenticated" : "unauthenticated", result.valid ? (pt ? "Input validado" : "Input validated") : (pt ? "Input precisa de correção" : "Input needs correction"), result.valid ? (pt ? "Pronto para configurar o download." : "Ready to configure the download.") : (pt ? "Corrija o arquivo e valide novamente." : "Edit the same file and validate again."));
         return result;
+    }
+
+    async function getInputColumnsForMapping() {
+        if (!selectedFilePath || !hasApi("get_input_columns")) return [];
+        try {
+            const info = await api().get_input_columns(selectedFilePath);
+            if (info && info.success) {
+                mappingColumns = info.columns || [];
+                renderMappingCard(mappingColumns, info.detected);
+                return mappingColumns;
+            }
+        } catch (_) { /* best effort */ }
+        return [];
     }
 
     async function validateCurrentFile() {
@@ -721,13 +890,17 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     $("#btn-validate-file").addEventListener("click", validateCurrentFile);
+    $("#btn-apply-mapping").addEventListener("click", applyColumnMapping);
     $("#btn-next-input").addEventListener("click", () => {
         if (!selectedFilePath || $("#btn-next-input").disabled) return;
         completeJourneyStep(2);
         validateCurrentFile();
     });
     $("#btn-next-hierarchy").addEventListener("click", () => completeJourneyStep(3));
-    $("#btn-next-destination").addEventListener("click", () => completeJourneyStep(4));
+    $("#btn-next-destination").addEventListener("click", () => {
+        renderDestinationPreview();
+        completeJourneyStep(4);
+    });
     $("#btn-next-review").addEventListener("click", () => {
         if (!$("#download-dir").value) {
             logToConsole("Error", "Choose a destination folder before continuing.");
@@ -740,20 +913,8 @@ document.addEventListener("DOMContentLoaded", () => {
     showJourneyStep(1);
     ensureDefaultDestination();
 
-    function requestFolderConfirmation() {
-        const modal = $("#folder-confirm-modal");
-        const directory = $("#download-dir").value || "Downloads/CoupaAttachments";
-        const parts = hierarchyOrder.length ? hierarchyOrder : ["Company"];
-        $("#folder-preview").innerText = `${directory}/\n└── ${parts.join("/\n    └── ")}\n        └── <PO>\n\nEach PO will be saved only after its Coupa attachments are found.`;
-        modal.hidden = false;
-        return new Promise((resolve) => {
-            const finish = (value) => { modal.hidden = true; resolve(value); };
-            $("#btn-confirm-folder-run").onclick = () => finish(true);
-            $("#btn-cancel-folder-run").onclick = () => finish(false);
-            $("#btn-cancel-folder-confirm").onclick = () => finish(false);
-        });
-    }
-
+    // The folder structure is confirmed between steps 3 and 4 (preview in the
+    // destination panel). The old modal no longer interrupts the start action.
     $("#btn-start-run").addEventListener("click", async () => {
         if (!selectedFilePath) {
             logToConsole("Error", "Please select an input file before starting.");
@@ -763,11 +924,6 @@ document.addEventListener("DOMContentLoaded", () => {
         const validation = await validateCurrentFile();
         if (!validation.valid) {
             logToConsole("Error", "Fix the validation errors and validate the file again.");
-            return;
-        }
-
-        if (!(await requestFolderConfirmation())) {
-            $("#btn-start-run").disabled = false;
             return;
         }
 
@@ -1112,21 +1268,34 @@ document.addEventListener("DOMContentLoaded", () => {
 
     async function loadHistory() {
         const body = $("#history-list");
-        body.innerHTML = '<tr><td colspan="6" class="empty-state">Loading runs…</td></tr>';
+        body.innerHTML = '<tr><td colspan="7" class="empty-state">Loading runs…</td></tr>';
         if (!hasApi("get_session_history")) {
-            body.innerHTML = '<tr><td colspan="6" class="empty-state">History is available in the desktop app.</td></tr>';
+            body.innerHTML = '<tr><td colspan="7" class="empty-state">History is available in the desktop app.</td></tr>';
             return;
         }
         try {
             const history = await api().get_session_history();
-            if (!history.length) { body.innerHTML = '<tr><td colspan="6" class="empty-state">No runs yet.</td></tr>'; return; }
+            if (!history.length) { body.innerHTML = '<tr><td colspan="7" class="empty-state">No runs yet.</td></tr>'; return; }
+            const pt = appSettings.language === "pt-BR";
             body.innerHTML = history.map((session) => {
                 const status = String(session.status || "PENDING").toUpperCase();
-                return `<tr><td>#${session.id}</td><td>${escapeHtml(session.input_file)}</td><td>${escapeHtml(new Date(session.created_at).toLocaleString())}</td><td>${session.total_pos || 0}</td><td><span class="status-badge status-${status.toLowerCase()}">${status}</span></td><td class="history-actions"><button class="btn btn-secondary btn-small btn-view-details" data-id="${session.id}" type="button">Details</button><button class="btn btn-danger btn-small btn-delete-run" data-id="${session.id}" data-input="${escapeHtml(session.input_file || "")}" type="button">Delete</button></td></tr>`;
+                const description = String(session.description || "").trim();
+                const descriptionCell = description
+                    ? `<td class="run-description-cell" title="${escapeHtml(description)}">${escapeHtml(description.length > 60 ? description.slice(0, 60) + "…" : description)}</td>`
+                    : '<td class="run-description-cell empty">—</td>';
+                return `<tr><td>#${session.id}</td><td><button class="coupa-link history-input-link" data-session="${session.id}" title="${pt ? "Abrir o input preservado desta execução" : "Open this run's preserved input"}" type="button">${escapeHtml(session.input_file)}</button></td>${descriptionCell}<td>${escapeHtml(new Date(session.created_at).toLocaleString())}</td><td>${session.total_pos || 0}</td><td><span class="status-badge status-${status.toLowerCase()}">${status}</span></td><td class="history-actions"><button class="btn btn-secondary btn-small btn-view-details" data-id="${session.id}" type="button">${pt ? "Detalhes" : "Details"}</button><button class="btn btn-danger btn-small btn-delete-run" data-id="${session.id}" data-input="${escapeHtml(session.input_file || "")}" type="button">${pt ? "Excluir" : "Delete"}</button></td></tr>`;
             }).join("");
             body.querySelectorAll(".btn-view-details").forEach((button) => button.addEventListener("click", () => openDetailsModal(button.dataset.id)));
             body.querySelectorAll(".btn-delete-run").forEach((button) => button.addEventListener("click", () => deleteRun(button)));
-        } catch (error) { body.innerHTML = `<tr><td colspan="6" class="empty-state">Could not load history: ${escapeHtml(error.message || error)}</td></tr>`; }
+            body.querySelectorAll(".history-input-link").forEach((button) => button.addEventListener("click", async () => {
+                if (!hasApi("open_input_file")) {
+                    logToConsole("Warning", "Input opening is available in the desktop app.");
+                    return;
+                }
+                const result = await api().open_input_file(Number(button.dataset.session));
+                if (!result.success) logToConsole("Error", result.error || "Could not open the preserved input file.");
+            }));
+        } catch (error) { body.innerHTML = `<tr><td colspan="7" class="empty-state">Could not load history: ${escapeHtml(error.message || error)}</td></tr>`; }
     }
 
     const modal = $("#details-modal");
@@ -1349,6 +1518,28 @@ document.addEventListener("DOMContentLoaded", () => {
         $("#modal-title").innerText = `Run #${sessionId}`;
         $("#modal-file").innerText = currentDetails.session.input_file;
         $("#modal-status").innerText = currentDetails.session.status;
+        const descriptionInput = $("#run-description-input");
+        descriptionInput.value = currentDetails.session.description || "";
+        $("#btn-save-run-description").onclick = async () => {
+            if (!hasApi("set_run_description")) {
+                alert("Run description saving is available in the desktop app.");
+                return;
+            }
+            const button = $("#btn-save-run-description");
+            button.disabled = true;
+            const result = await api().set_run_description(sessionId, descriptionInput.value.trim());
+            button.disabled = false;
+            if (!result.success) {
+                logToConsole("Error", result.error || "Could not save the run description.");
+                return;
+            }
+            currentDetails.session.description = descriptionInput.value.trim();
+            logToConsole("Success", appSettings.language === "pt-BR" ? "Descrição da execução salva." : "Run description saved.");
+            loadHistory();
+        };
+        descriptionInput.addEventListener("keydown", (event) => {
+            if (event.key === "Enter") $("#btn-save-run-description").click();
+        });
         const retryEvents = currentDetails.retry_events || [];
         $("#retry-history-list").hidden = !retryEvents.length;
         $("#retry-history-items").innerHTML = retryEvents.map((event) => `<li>${escapeHtml(event.po_number || "All errors")} · ${escapeHtml(event.status_before || "—")} → ${escapeHtml(event.status_after || "PENDING")} · ${escapeHtml(event.completed_at || event.requested_at || "")}</li>`).join("");
@@ -1544,7 +1735,14 @@ document.addEventListener("DOMContentLoaded", () => {
     let startupChecksDone = false;
     async function runStartupChecks() {
         if (startupChecksDone) return;
-        startupChecksDone = true;
+        // The pywebview bridge may not be exposed yet when the fallback timer
+        // fires; retry until the API is actually available so the saved
+        // language/font settings are applied on the first render.
+        let attempts = 0;
+        while (!hasApi("get_app_settings") && attempts < 40) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            attempts += 1;
+        }        startupChecksDone = true;
         initializeAuth();
         await loadSettings();
         checkForUpdates();

--- a/ContractDownloader/src/gui/web/index.html
+++ b/ContractDownloader/src/gui/web/index.html
@@ -45,7 +45,7 @@
 
             <section class="screen active" id="screen-new">
                 <div class="intro-block new-run-intro">
-                    <div><p class="eyebrow">NEW RUN JOURNEY</p><h2 id="journey-title">Choose your input</h2><p id="journey-subtitle">Start with a completed CSV or Excel file, or create a new template.</p><button class="btn btn-secondary btn-small" id="btn-start-over" type="button">Start over</button></div>
+                    <div><p class="eyebrow">NEW RUN JOURNEY</p><h2 id="journey-title">Choose your input</h2><p id="journey-subtitle">Start with a completed CSV or Excel file, or create a new template.</p></div>
                     <div class="step-indicator journey-steps" aria-label="Run preparation steps">
                         <button class="step active" data-journey-step="1" type="button"><b>1</b><span>Input</span></button><i></i>
                         <button class="step" data-journey-step="2" type="button" disabled><b>2</b><span>Validate</span></button><i></i>
@@ -71,6 +71,11 @@
                     <article class="workflow-card journey-card narrow-card">
                         <div class="card-heading"><span class="card-index">02</span><div><h3>Validate your input</h3><p>Review the file before any run is created. Correct it in the same file if needed.</p></div></div>
                         <div class="validation-file-summary"><span class="file-type">FILE</span><strong id="validation-filename">No file selected</strong></div>
+                        <div class="column-mapping-card" id="column-mapping-card" hidden>
+                            <div class="mapping-heading"><strong id="mapping-title">Map the file columns</strong><p id="mapping-subtitle">The required columns were not found automatically. Tell the app which columns hold the PO number and the supplier.</p></div>
+                            <div class="mapping-fields"><label>PO number column<select id="mapping-po-select"></select></label><label>Supplier column<select id="mapping-supplier-select"></select></label></div>
+                            <button class="btn btn-secondary" id="btn-apply-mapping" type="button">Apply mapping and validate</button>
+                        </div>
                         <div class="validation-feedback" id="validation-feedback" hidden></div>
                         <button class="btn btn-secondary btn-block" id="btn-validate-file" type="button">Validate input</button>
                         <div class="journey-footer"><button class="btn btn-quiet" data-journey-back="1" type="button">Back</button><button class="btn btn-primary btn-large" id="btn-next-hierarchy" type="button" disabled>Continue to folders</button></div>
@@ -79,15 +84,22 @@
 
                 <div class="journey-panel" data-journey-panel="3" hidden>
                     <article class="workflow-card journey-card narrow-card">
-                        <div class="card-heading"><span class="card-index">03</span><div><h3>Arrange folder hierarchy</h3><p>Drag the levels into the order that should be used for downloaded files.</p></div></div>
-                        <div class="folder-guide journey-folder-guide"><ol class="folder-hierarchy" id="folder-hierarchy"><li class="hierarchy-empty">Validate the input to load its folder levels.</li></ol><small>Columns after <code>&lt;|&gt;</code> become folders. Empty values become <code>Unknown</code>.</small></div>
+                        <div class="card-heading"><span class="card-index">03</span><div><h3>Arrange folder hierarchy</h3><p>Supplier is always the first level and the PO is the last. Drag the levels in between to reorder them.</p></div></div>
+                        <div class="folder-guide journey-folder-guide">
+                            <ol class="folder-hierarchy" id="folder-hierarchy"><li class="hierarchy-empty">Validate the input to load its folder levels.</li></ol>
+                            <div class="hierarchy-disabled" id="hierarchy-disabled" hidden><h4>Disabled columns</h4><p>These columns stay in the input and in the final report, but do not create folders.</p><ul id="hierarchy-disabled-list"></ul></div>
+                            <div class="hierarchy-warnings" id="hierarchy-warnings" hidden></div>
+                            <small>Columns after <code>&lt;|&gt;</code> become folders. Empty values become <code>Unknown</code>. Columns without any value are ignored.</small>
+                        </div>
                         <div class="journey-footer"><button class="btn btn-quiet" data-journey-back="2" type="button">Back</button><button class="btn btn-primary btn-large" id="btn-next-destination" type="button">Continue to destination</button></div>
                     </article>
                 </div>
 
                 <div class="journey-panel" data-journey-panel="4" hidden>
                     <article class="workflow-card journey-card narrow-card">
-                        <div class="card-heading"><span class="card-index">04</span><div><h3>Choose the save location</h3><p>Select the parent folder where this run should store its attachments.</p></div></div>
+                        <div class="card-heading"><span class="card-index">04</span><div><h3>Confirm the folder structure</h3><p>This is how downloaded files will be organized. Confirm it, then choose the save location.</p></div></div>
+                        <div class="folder-preview-block"><pre class="folder-preview" id="destination-preview"></pre></div>
+                        <div class="card-heading destination-heading"><span class="card-index">04b</span><div><h3>Choose the save location</h3><p>Select the parent folder where this run should store its attachments.</p></div></div>
                         <label class="field-label" for="download-dir">Download folder</label><div class="input-with-action"><input id="download-dir" type="text" placeholder="Choose a folder" autocomplete="off"><button class="btn btn-secondary" id="btn-choose-dir" type="button">Choose folder</button></div>
                         <div class="destination-note"><span>i</span><span>Existing valid files are preserved during retries.</span></div>
                         <div class="journey-footer"><button class="btn btn-quiet" data-journey-back="3" type="button">Back</button><button class="btn btn-primary btn-large" id="btn-next-review" type="button" disabled>Review run</button></div>
@@ -99,7 +111,7 @@
                         <div class="card-heading"><span class="card-index">05</span><div><h3>Review and start</h3><p>Everything is ready. Confirm these settings to begin the download.</p></div></div>
                         <div class="review-list"><div><span>Input file</span><strong id="review-file">—</strong></div><div><span>Folder hierarchy</span><strong id="review-hierarchy">—</strong></div><div><span>Save location</span><strong id="review-destination">—</strong><small class="review-destination-hierarchy" id="review-destination-hierarchy"></small></div></div>
                         <div class="ready-panel"><span class="status-dot unauthenticated" id="ready-indicator"></span><div><strong id="ready-title">Ready to start</strong><small id="ready-detail">The run will be created after confirmation.</small></div></div>
-                        <div class="journey-footer"><button class="btn btn-quiet" data-journey-back="4" type="button">Back</button><button class="btn btn-primary btn-large" id="btn-start-run" type="button">Start download</button></div>
+                        <div class="journey-footer"><button class="btn btn-quiet" data-journey-back="4" type="button">Back</button><button class="btn btn-danger-ghost" id="btn-start-over" type="button">Start over</button><button class="btn btn-primary btn-large" id="btn-start-run" type="button">Start download</button></div>
                     </article>
                 </div>
                 <div class="active-run-banner" id="active-run-banner" hidden><div><strong>A download is already running.</strong><span>Return to Active run to monitor it.</span></div><button class="btn btn-secondary" id="btn-go-active-run" type="button">View active run</button></div>
@@ -119,7 +131,7 @@
 
             <section class="screen" id="screen-history" hidden>
                 <div class="intro-block"><div><p class="eyebrow">AUDIT TRAIL</p><h2>Run history</h2><p>Review GUI results, inspect PO-level errors, and export a report. CLI pipeline runs remain separate.</p></div><div class="history-toolbar"><button class="btn btn-secondary" id="btn-refresh-history" type="button">Refresh</button><button class="btn btn-danger" id="btn-clear-history" type="button">Delete all history</button></div></div>
-                <article class="history-card"><div class="table-wrap"><table class="history-table"><thead><tr><th>Run</th><th>Input</th><th>Started</th><th>POs</th><th>Result</th><th>Actions</th></tr></thead><tbody id="history-list"><tr><td colspan="6" class="empty-state">No runs yet.</td></tr></tbody></table></div></article>
+                <article class="history-card"><div class="table-wrap"><table class="history-table"><thead><tr><th>Run</th><th>Input</th><th>Description</th><th>Started</th><th>POs</th><th>Result</th><th>Actions</th></tr></thead><tbody id="history-list"><tr><td colspan="7" class="empty-state">No runs yet.</td></tr></tbody></table></div></article>
             </section>
 
             <section class="screen" id="screen-learn" hidden>
@@ -154,10 +166,6 @@
         </main>
     </div>
 
-    <div class="modal" id="folder-confirm-modal" hidden>
-        <div class="modal-card folder-confirm-card"><div class="modal-header"><div><p class="eyebrow">CONFIRM DESTINATION</p><h3>Review folder structure</h3><p class="modal-description">Attachments will be saved using this structure:</p></div><button class="icon-btn" id="btn-cancel-folder-confirm" type="button">×</button></div><pre class="folder-preview" id="folder-preview"></pre><div class="modal-footer"><button class="btn btn-secondary" id="btn-cancel-folder-run" type="button">Cancel</button><button class="btn btn-primary" id="btn-confirm-folder-run" type="button">Confirm and start</button></div></div>
-    </div>
-
     <div class="modal" id="retry-edit-modal" hidden>
         <div class="modal-card narrow-modal"><div class="modal-header"><div><p class="eyebrow">EDIT BEFORE RETRY</p><h3>Confirm PO number</h3></div><button class="icon-btn" id="btn-close-retry-edit" type="button">×</button></div><p class="modal-description">Edit the PO number only if the original value was incorrect. The corrected PO will be tested before anything is saved.</p><label class="field-label" for="retry-po-input">PO number</label><input id="retry-po-input" class="modal-input" type="text" autocomplete="off"><div class="modal-footer"><button class="btn btn-quiet" id="btn-cancel-retry-edit" type="button">Cancel</button><button class="btn btn-primary" id="btn-confirm-retry-edit" type="button">Confirm and retry</button></div></div>
     </div>
@@ -167,7 +175,7 @@
     </div>
 
     <div class="modal" id="details-modal" hidden>
-        <div class="modal-card"><div class="modal-header"><div><p class="eyebrow">RUN DETAILS</p><h3 id="modal-title">Session details</h3></div><button class="icon-btn" id="btn-close-modal" type="button">×</button></div><div class="modal-summary"><span>Input <strong id="modal-file">—</strong></span><span>Status <strong id="modal-status">—</strong></span><button class="btn btn-secondary btn-small" id="btn-open-input" type="button">Open input file</button></div><div class="retry-history-list" id="retry-history-list" hidden><h4>Retry history</h4><ul id="retry-history-items"></ul></div><div class="company-status-list"><h4>Supplier checks</h4><ul id="company-status-items"></ul></div><div class="po-details-list"><div class="details-toolbar"><h4>Purchase orders</h4><fieldset class="status-filter-group" id="status-filter"><legend>Show statuses</legend><label class="status-filter-option"><input type="checkbox" data-status-all checked><span>All</span></label><label class="status-filter-option"><input type="checkbox" data-status="SUCCESS" checked><span>Success</span></label><label class="status-filter-option"><input type="checkbox" data-status="ERROR" checked><span>Error</span></label><label class="status-filter-option"><input type="checkbox" data-status="PENDING" checked><span>Pending</span></label><label class="status-filter-option"><input type="checkbox" data-status="SKIPPED_VERIFICATION_REQUIRED" checked><span>Skipped</span></label></fieldset></div><div class="table-wrap"><table class="modal-pos-table"><thead><tr><th>PO</th><th>Supplier</th><th>Status</th><th class="retry-column">Retry</th><th class="message-column">Message</th></tr></thead><tbody id="modal-pos-tbody"></tbody></table></div></div><div class="modal-footer"><button class="btn btn-danger" id="btn-retry-errors" type="button">Retry failed POs</button><button class="btn btn-secondary" id="btn-export-modal-report" type="button">Export report</button></div></div>
+        <div class="modal-card"><div class="modal-header"><div><p class="eyebrow">RUN DETAILS</p><h3 id="modal-title">Session details</h3></div><button class="icon-btn" id="btn-close-modal" type="button">×</button></div><div class="run-description-row"><label class="field-label" for="run-description-input">Run description</label><div class="input-with-action"><input id="run-description-input" type="text" maxlength="200" placeholder="Why was this run made? For whom?" autocomplete="off"><button class="btn btn-secondary" id="btn-save-run-description" type="button">Save</button></div><small class="description-hint">Free text that appears in history to explain the purpose of this run (request, analysis, requester).</small></div><div class="modal-summary"><span>Input <strong id="modal-file">—</strong></span><span>Status <strong id="modal-status">—</strong></span><button class="btn btn-secondary btn-small" id="btn-open-input" type="button">Open input file</button></div><div class="retry-history-list" id="retry-history-list" hidden><h4>Retry history</h4><ul id="retry-history-items"></ul></div><div class="company-status-list"><h4>Supplier checks</h4><ul id="company-status-items"></ul></div><div class="po-details-list"><div class="details-toolbar"><h4>Purchase orders</h4><fieldset class="status-filter-group" id="status-filter"><legend>Show statuses</legend><label class="status-filter-option"><input type="checkbox" data-status-all checked><span>All</span></label><label class="status-filter-option"><input type="checkbox" data-status="SUCCESS" checked><span>Success</span></label><label class="status-filter-option"><input type="checkbox" data-status="ERROR" checked><span>Error</span></label><label class="status-filter-option"><input type="checkbox" data-status="PENDING" checked><span>Pending</span></label><label class="status-filter-option"><input type="checkbox" data-status="SKIPPED_VERIFICATION_REQUIRED" checked><span>Skipped</span></label></fieldset></div><div class="table-wrap"><table class="modal-pos-table"><thead><tr><th>PO</th><th>Supplier</th><th>Status</th><th class="retry-column">Retry</th><th class="message-column">Message</th></tr></thead><tbody id="modal-pos-tbody"></tbody></table></div></div><div class="modal-footer"><button class="btn btn-danger" id="btn-retry-errors" type="button">Retry failed POs</button><button class="btn btn-secondary" id="btn-export-modal-report" type="button">Export report</button></div></div>
     </div>
     <div class="modal" id="diagnostics-modal" hidden>
         <div class="modal-card diagnostics-card"><div class="modal-header"><div><p class="eyebrow">SUPPORT TOOL</p><h3>Host diagnostics</h3><p class="modal-description">This report checks compatibility, connectivity and local permissions. It excludes passwords, cookies and PO contents.</p></div><button class="icon-btn" id="btn-close-diagnostics" type="button">×</button></div><pre class="diagnostics-report" id="diagnostics-report">Running diagnostics…</pre><div class="modal-footer"><button class="btn btn-secondary" id="btn-save-diagnostics" type="button" disabled>Save report</button><button class="btn btn-primary" id="btn-copy-diagnostics" type="button" disabled>Copy report</button></div></div>

--- a/ContractDownloader/src/gui/web/style.css
+++ b/ContractDownloader/src/gui/web/style.css
@@ -248,3 +248,53 @@ button:disabled { cursor: not-allowed; opacity: .52; }
 
 @media (max-width: 1000px) { .sidebar { width: 200px; flex-basis: 200px; }.main-content { padding: 22px 25px 24px; }.metrics-grid { grid-template-columns: 1fr 1fr; }.metric-card.wide { grid-column: span 2; }.new-run-intro { grid-template-columns: minmax(0, 1fr) 360px; }.journey-steps { width: 360px; }.step span { display: none; }.step b { font-size: 9px; } }
 @media (max-width: 680px) { html, body { height: auto; min-height: 100%; overflow: auto; } .app-shell { height: auto; min-height: 100vh; display: block; overflow: visible; }.sidebar { width: 100%; height: auto; min-height: 100vh; position: relative; zoom: calc(1 / var(--font-scale)); }.sidebar-bottom { margin-top: 20px; }.nav-menu { display: flex; flex-wrap: wrap; }.main-content { width: auto; height: auto; min-height: 100vh; overflow: visible; padding: 22px 16px; }.metrics-grid { grid-template-columns: 1fr; }.metric-card.wide { grid-column: auto; }.intro-block { align-items: flex-start; flex-direction: column; }.new-run-intro { display: flex; gap: 16px; }.journey-steps { width: 100%; justify-content: space-between; }.journey-panel { max-width: none; }.journey-card { min-height: 390px; }.template-actions { align-items: stretch; flex-direction: column; }.journey-footer { align-items: stretch; flex-wrap: wrap; }.journey-footer .btn-primary, .journey-footer .btn-large { flex: 1; }.learn-grid { grid-template-columns: 1fr; }.settings-section { grid-template-columns: 1fr; gap: 14px; }.toggle-field { justify-self: start; }.settings-footer { align-items: stretch; flex-direction: column; } }
+
+/* --- Validation grouped dashboard + column mapping --- */
+.validation-dashboard { display: grid; gap: 7px; margin: 6px 0 2px; }
+.validation-group { display: grid; gap: 6px; padding: 10px 11px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface-soft); }
+.validation-group-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 9px; border-radius: 6px; font-size: 11px; }
+.validation-group-head strong { font-size: 11px; }
+.validation-group-head span { min-width: 22px; padding: 2px 6px; border-radius: 10px; text-align: center; font-size: 10px; font-weight: 800; }
+.validation-group-head.validation-error { color: var(--red); background: var(--red-soft); }
+.validation-group-head.validation-warning { color: var(--amber); background: var(--amber-soft); }
+.validation-group p { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.45; }
+.validation-group .btn { justify-self: start; }
+.column-mapping-card { display: grid; gap: 10px; margin-bottom: 14px; padding: 13px 14px; border: 1px solid #d8c9a8; border-radius: 9px; background: #fdf8ec; }
+.column-mapping-card[hidden] { display: none; }
+.mapping-heading strong { display: block; margin-bottom: 3px; color: var(--navy); font-size: 12px; }
+.mapping-heading p { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.45; }
+.mapping-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.mapping-fields label { display: grid; gap: 5px; color: var(--muted); font-size: 10px; font-weight: 700; }
+.mapping-fields select { border: 1px solid var(--line); border-radius: 7px; padding: 8px 9px; color: var(--ink); background: var(--surface); font-size: 11px; }
+.column-mapping-card .btn { justify-self: start; }
+
+/* --- Hierarchy: fixed levels, toggles, disabled list, warnings --- */
+.folder-hierarchy li.hierarchy-fixed { cursor: default; border-color: #cfe2ec; background: #eef6fa; color: var(--navy); }
+.folder-hierarchy li.hierarchy-fixed .hierarchy-level { color: var(--green); background: var(--green-soft); }
+.folder-hierarchy .hierarchy-lock { color: var(--muted-2); font-size: 10px; }
+.folder-hierarchy .hierarchy-toggle { border: 0; border-radius: 5px; width: 20px; height: 20px; margin-left: auto; color: var(--red); background: var(--red-soft); font-size: 13px; line-height: 1; cursor: pointer; }
+.folder-hierarchy .hierarchy-toggle:hover { background: #f2caca; }
+.hierarchy-disabled { margin: 12px 0; padding: 10px 12px; border: 1px dashed #c9b8a0; border-radius: 8px; background: #faf6ef; }
+.hierarchy-disabled[hidden] { display: none; }
+.hierarchy-disabled h4 { margin: 0 0 3px; color: var(--muted); font-size: 10px; letter-spacing: .06em; text-transform: uppercase; }
+.hierarchy-disabled p { margin: 0 0 8px; color: var(--muted-2); font-size: 10px; line-height: 1.4; }
+.hierarchy-disabled ul { display: grid; gap: 5px; margin: 0; padding: 0; list-style: none; }
+.hierarchy-disabled li { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 9px; border: 1px solid var(--line); border-radius: 6px; color: var(--muted); background: var(--surface); font-size: 10px; }
+.hierarchy-disabled .hierarchy-toggle { color: var(--green); background: var(--green-soft); }
+.hierarchy-warnings { display: grid; gap: 5px; margin: 8px 0; }
+.hierarchy-warnings[hidden] { display: none; }
+.folder-preview-block { margin-bottom: 20px; }
+.folder-preview-block .folder-preview { margin: 0; }
+.destination-heading { margin-top: 4px; }
+
+/* --- Run description (details modal) --- */
+.run-description-row { display: grid; gap: 6px; padding: 12px 24px; border-bottom: 1px solid var(--line); }
+.run-description-row .field-label { margin: 0; }
+.description-hint { color: var(--muted-2); font-size: 10px; line-height: 1.4; }
+.history-input-link { font-size: 12px; }
+.run-description-cell { max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 11px; }
+.run-description-cell.empty { color: var(--muted-2); }
+
+/* --- Start over ghost danger button --- */
+.btn-danger-ghost { color: var(--red); background: transparent; border-color: #f2caca; }
+.btn-danger-ghost:hover { background: var(--red-soft); }

--- a/ContractDownloader/src/main.py
+++ b/ContractDownloader/src/main.py
@@ -1,8 +1,10 @@
 import os
 import sys
+import time
 import asyncio
 import subprocess
 import threading
+import shutil
 from pathlib import Path
 from urllib.parse import quote, urlparse
 
@@ -157,21 +159,54 @@ class TurboAPI(AppAPI):
             self._pending_input_path = None
         return result
 
+    def get_input_columns(self, filepath: str) -> dict:
+        return super().get_input_columns(filepath)
+
+    def map_input_columns(self, filepath: str, mapping: dict) -> dict:
+        return super().map_input_columns(filepath, mapping)
+
+    def _working_copy_for(self, filepath: str) -> tuple[str, bool]:
+        """Return (path, copied) for a selected input.
+
+        When the user picks an input that is the archived snapshot of another
+        run, that snapshot must stay immutable (audit evidence). The new run
+        works on a private copy instead.
+        """
+        selected = str(Path(filepath).expanduser().resolve())
+        try:
+            with self.cli_backend._connect() as conn:
+                row = conn.execute(
+                    "SELECT id FROM sessions WHERE input_file_path = ? ORDER BY id DESC LIMIT 1",
+                    (selected,),
+                ).fetchone()
+        except Exception:
+            row = None
+        if not row:
+            return selected, False
+        work_dir = Path.home() / ".contract_downloader" / "working"
+        work_dir.mkdir(parents=True, exist_ok=True)
+        source = Path(selected)
+        target = work_dir / f"run_{time.strftime('%Y%m%d_%H%M%S')}_{source.name}"
+        shutil.copy2(source, target)
+        return str(target), True
+
     def import_file(self, filepath: str) -> dict:
         """Validate and stage the input; the CLI creates the real session."""
-        validation = self.validate_input_file(filepath)
+        working_path, copied = self._working_copy_for(filepath)
+        validation = self.validate_input_file(working_path)
         if not validation.get("valid"):
             return {
                 "success": False,
                 "error": "Input validation failed.",
                 "validation": validation,
             }
-        self._pending_input_path = str(Path(filepath).expanduser().resolve())
+        self._pending_input_path = working_path
         return {
             "success": True,
             "session_id": 0,
             "total_pos": validation.get("valid_po_count", 0),
             "backend": "cli",
+            "working_copy": copied,
         }
 
     def start_download(
@@ -181,6 +216,7 @@ class TurboAPI(AppAPI):
         concurrency: int = 4,
         hierarchy_order: list[str] | None = None,
         retry_attempts: int | None = None,
+        description: str | None = None,
     ) -> dict:
         if not self._pending_input_path:
             return {"success": False, "error": "No validated input file is staged."}
@@ -193,6 +229,7 @@ class TurboAPI(AppAPI):
         selected_path = Path(self._absolute_user_path(selected_dir))
         persistent_root = selected_path.parent if selected_path.name.startswith("run_") else selected_path
         self._persist_download_root(str(persistent_root))
+        mapping = self._mapping_for(self._pending_input_path) or None
         return self.cli_backend.start(
             self._pending_input_path,
             str(selected_path),
@@ -202,7 +239,12 @@ class TurboAPI(AppAPI):
             retry_attempts=effective_retry_attempts,
             msg_processing=msg_processing,
             deduplicate_files=deduplicate_files,
+            description=description,
+            column_mapping=mapping,
         )
+
+    def set_run_description(self, session_id: int, description: str) -> dict:
+        return self.cli_backend.set_run_description(int(session_id), description)
 
     def get_active_session_status(self, session_id: int) -> dict:
         return self.cli_backend.get_status(session_id)
@@ -335,9 +377,13 @@ def _activate_macos_window() -> None:
 
 
 def calculate_window_geometry(screen_width: int, screen_height: int, screen_x: int = 0, screen_y: int = 0) -> dict[str, int]:
-    """Size the window to 85% of the screen width and center it."""
-    width = max(980, round(screen_width * 0.85))
-    height = min(820, max(700, round(screen_height * 0.85)))
+    """Size the window to 88% of the screen width and center it.
+
+    The larger default (minimum 1080px) gives the title, the authentication
+    card, and the translated strings enough room so nothing is compressed.
+    """
+    width = max(1080, round(screen_width * 0.88))
+    height = min(840, max(720, round(screen_height * 0.88)))
     return {
         "width": width,
         "height": height,
@@ -379,7 +425,7 @@ def main():
         x=geometry["x"],
         y=geometry["y"],
         screen=primary_screen,
-        min_size=(980, 700),
+        min_size=(1000, 680),
         resizable=True,
     )
     if sys.platform == "darwin":

--- a/ContractDownloader/tests/e2e/test_cross_platform.py
+++ b/ContractDownloader/tests/e2e/test_cross_platform.py
@@ -107,7 +107,7 @@ def test_output_subdir_uses_posix_separators_regardless_of_platform() -> None:
     row = pd.Series({"Year": "2026", "Quarter": "Q1", "BU": "Americas"})
     subdir = _build_output_subdir(row, "Supplier", ["Year", "Quarter", "BU"], has_hierarchy_data=True)
     assert "\\" not in subdir
-    assert subdir == "2026/Q1/Americas"
+    assert subdir == "Supplier/2026/Q1/Americas"
 
 
 # ── Settings JSON survives round-trip on both platforms ─────────────────

--- a/ContractDownloader/tests/test_cli_supervisor.py
+++ b/ContractDownloader/tests/test_cli_supervisor.py
@@ -124,3 +124,52 @@ def test_history_status_translation_preserves_filter_inputs():
     assert 'id="btn-save-retry-result"' in html
     assert 'id="btn-discard-retry-result"' in html
     assert '#retry-edit-modal, #retry-result-modal' in (web_root / "style.css").read_text(encoding="utf-8")
+
+
+# ── Run description and archived-input protection ────────────────────────
+
+
+def test_set_run_description_updates_session(tmp_path):
+    from src.gui.cli_supervisor import CliProcessSupervisor
+    from src.db.session_db import SessionDB
+    SessionDB(str(tmp_path / "sessions.db")).close()
+    supervisor = CliProcessSupervisor()
+    supervisor.db_path = tmp_path / "sessions.db"
+    with supervisor._connect() as conn:
+        conn.execute("INSERT INTO sessions (input_file, status) VALUES ('input.csv', 'SUCCESS')")
+        session_id = conn.execute("SELECT id FROM sessions ORDER BY id DESC LIMIT 1").fetchone()["id"]
+
+    result = supervisor.set_run_description(session_id, "Análise para auditoria")
+    assert result["success"] is True
+    with supervisor._connect() as conn:
+        row = conn.execute("SELECT description FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    assert row["description"] == "Análise para auditoria"
+
+
+def test_archived_input_becomes_read_only_after_run(tmp_path):
+    from src.gui.cli_supervisor import CliProcessSupervisor
+    from src.db.session_db import SessionDB
+    SessionDB(str(tmp_path / "sessions.db")).close()
+    supervisor = CliProcessSupervisor()
+    supervisor.db_path = tmp_path / "sessions.db"
+    archive = tmp_path / "run_1" / "input_source_1.csv"
+    archive.parent.mkdir()
+    archive.write_text("PO_NUMBER;SUPPLIER\nPO1;CompA\n", encoding="utf-8")
+    with supervisor._connect() as conn:
+        conn.execute(
+            "INSERT INTO sessions (id, input_file, input_file_path, status) VALUES (1, 'input.csv', ?, 'SUCCESS')",
+            (str(archive),),
+        )
+    supervisor.session_id = 1
+
+    supervisor._protect_archived_inputs()
+
+    import stat
+    mode = stat.S_IMODE(archive.stat().st_mode)
+    assert mode == 0o444
+
+    # An explicit retry temporarily lifts the protection and re-applies it.
+    supervisor._set_file_readonly(archive, False)
+    archive.write_text("PO_NUMBER;SUPPLIER\nPO1;CompA\nPO2;CompB\n", encoding="utf-8")
+    supervisor._set_file_readonly(archive, True)
+    assert stat.S_IMODE(archive.stat().st_mode) == 0o444

--- a/ContractDownloader/tests/test_gui_api.py
+++ b/ContractDownloader/tests/test_gui_api.py
@@ -117,12 +117,20 @@ def test_edge_driver_version_components_can_be_compared():
     assert AppAPI._version_components("MSEdgeDriver 140.0.3485.54")[:3] == (140, 0, 3485)
 
 
-def test_window_uses_85_percent_width_and_is_centered():
+def test_window_uses_88_percent_width_and_is_centered():
     from src.main import calculate_window_geometry
 
     geometry = calculate_window_geometry(1512, 982)
 
-    assert geometry == {"width": 1285, "height": 820, "x": 114, "y": 81}
+    assert geometry == {"width": 1331, "height": 840, "x": 90, "y": 71}
+
+
+def test_window_minimum_width_gives_title_and_controls_room():
+    from src.main import calculate_window_geometry
+
+    small = calculate_window_geometry(900, 700)
+    assert small["width"] >= 1080
+    assert small["height"] >= 700
 
 
 def test_macos_coupa_url_uses_configured_default_handler(temp_db, monkeypatch):
@@ -222,4 +230,180 @@ def test_import_file_csv_hierarchy_output_subdir(temp_db, tmp_path):
         (session_id, "PO9001"),
     ).fetchone()
     assert row is not None
-    assert row["output_subdir"] == "2026/Q12026/Yellow_Wood"
+    assert row["output_subdir"] == "Manpowergroup_Inc/2026/Q12026/Yellow_Wood"
+
+
+# ── Column mapping and grouped validation ────────────────────────────────
+
+
+def test_validate_input_file_groups_errors_by_category(temp_db, tmp_path):
+    csv_path = tmp_path / "dirty.csv"
+    csv_path.write_text(
+        "PO_NUMBER;SUPPLIER\n"
+        "PO1;CompA\n"
+        "PO1;CompA\n"
+        "PO@2;CompB\n"
+        ";CompC\n",
+        encoding="utf-8",
+    )
+    api = AppAPI(temp_db, "/tmp/downloads")
+    result = api.validate_input_file(str(csv_path))
+
+    groups = {group["id"]: group for group in result["groups"]}
+    assert groups["duplicate_pos"]["fix_action"] == "remove_duplicate_pos"
+    assert groups["invalid_chars"]["fix_action"] == "clean_invalid_chars"
+    assert "partial_rows" in groups
+
+
+def test_validate_input_file_detects_blank_rows_in_xlsx(temp_db, tmp_path):
+    xlsx_path = tmp_path / "blank_rows.xlsx"
+    frame = pd.DataFrame({
+        "PO_NUMBER": ["PO1", None, "PO2"],
+        "SUPPLIER": ["CompA", None, "CompB"],
+    })
+    frame.to_excel(xlsx_path, index=False)
+    api = AppAPI(temp_db, "/tmp/downloads")
+    result = api.validate_input_file(str(xlsx_path))
+
+    groups = {group["id"]: group for group in result["groups"]}
+    assert groups["blank_rows"]["fix_action"] == "remove_blank_rows"
+    assert result["valid"] is False
+
+
+def test_repair_input_file_cleans_invalid_chars(temp_db, tmp_path):
+    csv_path = tmp_path / "dirty.csv"
+    csv_path.write_text(
+        "PO_NUMBER;SUPPLIER\n"
+        "PO@2;CompB\n"
+        "PO3;CompA\n",
+        encoding="utf-8",
+    )
+    api = AppAPI(temp_db, "/tmp/downloads")
+    result = api.repair_input_file(str(csv_path), ["clean_invalid_chars"])
+
+    assert result["success"] is True
+    assert result["cleaned_invalid_chars"] == 1
+    content = csv_path.read_text(encoding="utf-8-sig")
+    assert "PO2" in content
+    assert "PO@2" not in content
+
+
+def test_map_input_columns_enables_nonstandard_file(temp_db, tmp_path):
+    csv_path = tmp_path / "master_data.csv"
+    csv_path.write_text(
+        "Document;Vendor Name\n"
+        "PO1234;Acme Corp\n"
+        "PO5678;Globex\n",
+        encoding="utf-8",
+    )
+    api = AppAPI(temp_db, "/tmp/downloads")
+    info = api.get_input_columns(str(csv_path))
+    assert info["success"] is True
+    assert info["detected"]["po"] is None
+
+    mapped = api.map_input_columns(str(csv_path), {"po": "Document", "supplier": "Vendor Name"})
+    assert mapped["success"] is True
+    assert mapped["mapping"]["po"] == "Document"
+
+    validation = api.validate_input_file(str(csv_path))
+    assert validation["valid"] is True
+    assert validation["valid_po_count"] == 2
+
+    imported = api.import_file(str(csv_path))
+    assert imported["success"] is True
+    assert imported["total_pos"] == 2
+
+
+def test_import_file_supplier_is_always_first_level(temp_db, tmp_path):
+    csv_path = tmp_path / "hierarchy.csv"
+    csv_path.write_text(
+        "PO_NUMBER;SUPPLIER;<|>;Year\n"
+        "PO9001;Manpowergroup Inc.;;2026\n",
+        encoding="utf-8",
+    )
+    api = AppAPI(temp_db, "/tmp/downloads")
+    result = api.import_file(str(csv_path))
+    assert result["success"] is True
+    row = temp_db.conn.execute(
+        "SELECT output_subdir FROM po_downloads WHERE session_id = ? AND po_number = 'PO9001'",
+        (result["session_id"],),
+    ).fetchone()
+    assert row["output_subdir"] == "Manpowergroup_Inc/2026"
+
+
+def test_validate_input_file_reports_empty_hierarchy_columns(temp_db, tmp_path):
+    csv_path = tmp_path / "empty_col.csv"
+    csv_path.write_text(
+        "PO_NUMBER;SUPPLIER;<|>;Year;Country\n"
+        "PO1;CompA;;2026;\n",
+        encoding="utf-8",
+    )
+    api = AppAPI(temp_db, "/tmp/downloads")
+    result = api.validate_input_file(str(csv_path))
+    assert "Country" in result["empty_hierarchy_columns"]
+    assert "Year" not in result["empty_hierarchy_columns"]
+
+
+# ── Run description (audit context) ──────────────────────────────────────
+
+
+def test_session_description_persisted(temp_db):
+    db = SessionDB(temp_db.db_path)
+    session_id = db.create_session("file.xlsx", description="Análise para a Prianca — POs 2026")
+    session = db.get_session(session_id)
+    assert session["description"] == "Análise para a Prianca — POs 2026"
+
+    db.update_session_description(session_id, "Requerido por auditoria Q3")
+    assert db.get_session(session_id)["description"] == "Requerido por auditoria Q3"
+
+
+# ── Working copy for archived inputs (TurboAPI GUI bridge) ───────────────
+
+
+def test_archived_input_gets_working_copy_instead_of_in_place_edit(temp_db, monkeypatch, tmp_path):
+    """Reusing a previous run's archived input must copy it, never edit it."""
+    from src.main import TurboAPI
+    import sqlite3
+    from pathlib import Path
+
+    monkeypatch.setattr("src.gui.api.Path.home", lambda: tmp_path)
+    archive = tmp_path / "run_1" / "input_source_1.csv"
+    archive.parent.mkdir(parents=True)
+    original_content = "PO_NUMBER;SUPPLIER\nPO1;CompA\n"
+    archive.write_text(original_content, encoding="utf-8")
+
+    supervisor_db = tmp_path / ".contract_downloader" / "cli_sessions.db"
+    supervisor_db.parent.mkdir(parents=True)
+    conn = sqlite3.connect(str(supervisor_db))
+    conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY AUTOINCREMENT, input_file TEXT, input_file_path TEXT, status TEXT)")
+    conn.execute(
+        "INSERT INTO sessions (input_file, input_file_path, status) VALUES ('input_source_1.csv', ?, 'SUCCESS')",
+        (str(archive),),
+    )
+    conn.commit()
+    conn.close()
+
+    api = TurboAPI(temp_db, "/tmp/downloads")
+    api.cli_backend.db_path = supervisor_db
+
+    working, copied = api._working_copy_for(str(archive))
+
+    assert copied is True
+    assert working != str(archive)
+    assert Path(working).exists()
+    assert archive.read_text(encoding="utf-8") == original_content
+    assert Path(working).read_text(encoding="utf-8") == original_content
+
+
+def test_regular_input_is_not_copied(temp_db, monkeypatch, tmp_path):
+    from src.main import TurboAPI
+
+    monkeypatch.setattr("src.gui.api.Path.home", lambda: tmp_path)
+    source = tmp_path / "my_input.csv"
+    source.write_text("PO_NUMBER;SUPPLIER\nPO1;CompA\n", encoding="utf-8")
+    api = TurboAPI(temp_db, "/tmp/downloads")
+
+    working, copied = api._working_copy_for(str(source))
+
+    assert copied is False
+    assert working == str(source)

--- a/ContractDownloader/tests/test_input_schema.py
+++ b/ContractDownloader/tests/test_input_schema.py
@@ -1,0 +1,76 @@
+"""Tests for the shared column schema helpers (input_schema)."""
+
+import json
+
+import pytest
+
+from src.engine.input_schema import (
+    detect_required_columns,
+    normalize_column_name,
+    parse_mapping_env,
+    resolve_mapping,
+)
+
+
+def test_normalize_column_name_strips_separators_and_case():
+    assert normalize_column_name(" PO_NUMBER ") == "ponumber"
+    assert normalize_column_name("Vendor-Name") == "vendorname"
+    assert normalize_column_name("") == ""
+
+
+def test_detect_required_columns_finds_aliases():
+    detected = detect_required_columns(["PO Number", "Legal Entity", "Year"])
+    assert detected["po"] == "PO Number"
+    assert detected["supplier"] == "Legal Entity"
+
+
+def test_detect_required_columns_returns_none_when_missing():
+    detected = detect_required_columns(["Document", "Counterparty", "Year"])
+    assert detected["po"] is None
+    assert detected["supplier"] is None
+
+
+def test_resolve_mapping_prefers_explicit_mapping():
+    columns = ["Document", "Vendor Name", "PO_NUMBER"]
+    resolved = resolve_mapping(columns, {"po": "Document", "supplier": "Vendor Name"})
+    assert resolved == {"po": "Document", "supplier": "Vendor Name"}
+
+
+def test_resolve_mapping_fills_gaps_with_detection():
+    columns = ["PO_NUMBER", "Vendor Name"]
+    resolved = resolve_mapping(columns, {"supplier": "Vendor Name"})
+    assert resolved == {"po": "PO_NUMBER", "supplier": "Vendor Name"}
+
+
+def test_resolve_mapping_ignores_unknown_column_names():
+    columns = ["Document", "Vendor"]
+    resolved = resolve_mapping(columns, {"po": "DoesNotExist", "supplier": "Vendor"})
+    assert resolved["po"] is None
+    assert resolved["supplier"] == "Vendor"
+
+
+def test_parse_mapping_env_reads_json(monkeypatch):
+    monkeypatch.setenv("COUPA_COLUMN_MAPPING", json.dumps({"po": "Document", "supplier": "Vendor Name"}))
+    assert parse_mapping_env() == {"po": "Document", "supplier": "Vendor Name"}
+
+
+def test_parse_mapping_env_ignores_invalid_json(monkeypatch):
+    monkeypatch.setenv("COUPA_COLUMN_MAPPING", "not-json")
+    assert parse_mapping_env() is None
+
+
+def test_parse_mapping_env_none_when_absent(monkeypatch):
+    monkeypatch.delenv("COUPA_COLUMN_MAPPING", raising=False)
+    assert parse_mapping_env() is None
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("po", "po"),
+    ("PO", "po"),
+    ("pedido", "pedido"),
+    ("purchase order number", "purchaseordernumber"),
+])
+def test_po_aliases_are_covered(value, expected):
+    detected = detect_required_columns([value])
+    assert detected["po"] == value
+    assert normalize_column_name(value) == expected

--- a/PR_PLANS/26-ux-revisao-mapeamento-colunas-design-doc.md
+++ b/PR_PLANS/26-ux-revisao-mapeamento-colunas-design-doc.md
@@ -1,0 +1,92 @@
+# Design Doc: Revisão UX e Mapeamento de Colunas — Contract Downloader
+
+**Data:** 2026-07-31
+**Escopo:** Correções priorizadas na reunião de revisão (31/07) + mapeamento de colunas.
+
+## 1. Contexto
+
+A reunião de revisão identificou problemas de UX e confiabilidade no fluxo de "New Run":
+
+1. Janela com título comprimido e controles cortados.
+2. Idioma salvo (pt-BR) não aplicado na inicialização — só após abrir Settings.
+3. Botão de autenticação redundante quando já autenticado.
+4. "Start Over" posicionado no início do fluxo (não deve existir sem estado; deve ficar na etapa final).
+5. Validação com mensagens soltas, sem agrupar por tipo e sem ações de correção por grupo.
+6. Hierarquia de pastas ignora Supplier (deve ser Nível 1 fixo; PO nível final fixo); colunas 100% vazias devem gerar aviso e não criar pastas.
+7. Confirmação de estrutura de pastas aparece no início do download; deve aparecer entre as etapas 3 e 4 (preview) e não repetir.
+8. Input arquivado de run anterior pode ser alterado acidentalmente; deve ser snapshot protegido (exceção: retry explícito).
+9. Aba New Run acessível durante execução ativa (deve ficar travada).
+10. Sem descrição/título livre para a run (auditoria).
+
+**Incluído neste desenvolvimento:** mapeamento de colunas para inputs não padronizados (antes "fase futura").
+**Fora do escopo:** enriquecimento via Coupa, SharePoint, IA, Power BI, terminal headless, ETA/velocidade total, links clicáveis no log, notificação de conclusão.
+
+## 2. Decisões de design
+
+### 2.1 Mapeamento de colunas (novo)
+- Novo módulo `src/engine/input_schema.py` com funções puras:
+  - `normalize_column_name(col)` — normaliza para comparação (lowercase, sem não-alfanuméricos).
+  - `detect_required_columns(columns)` — detecta PO e Supplier pelos sinônimos atuais.
+  - `resolve_mapping(columns, mapping)` — valida mapeamento explícito {po, supplier}.
+- Persistência do mapeamento: `~/.contract_downloader/column_mappings.json`, chave = caminho absoluto do input. O mapeamento é reutilizado em validação/importação.
+- O pipeline CLI recebe o mapeamento via `COUPA_COLUMN_MAPPING` (JSON) e usa nas funções de criação de sessão e mapa de subdiretórios.
+- UI: se a validação falhar por colunas obrigatórias ausentes, exibe card de mapeamento (selects de colunas do arquivo → PO / Supplier) + "Aplicar mapeamento".
+
+### 2.2 Validação agrupada com correções por grupo
+- `validate_input_file` retorna `groups: [{id, title, count, rows, fix_action, fixable, severity}]`:
+  - `blank_rows` → fix `remove_blank_rows` (seguro)
+  - `duplicate_pos` → fix `remove_duplicate_pos` (seguro)
+  - `invalid_chars` → fix `clean_invalid_chars` (seguro, novo)
+  - `unusual_format` → sem correção automática (abrir arquivo para edição assistida)
+  - `missing_columns` → tratado pelo mapeamento
+- `repair_input_file` ganha `clean_invalid_chars` (CSV e XLSX).
+
+### 2.3 Hierarquia Supplier-first (fim a fim)
+- `_build_output_subdir`: sempre prefixa Supplier como primeiro nível.
+- `_extract_hierarchy_columns`: remove colunas 100% vazias da lista ativa (GUI continua exibindo o aviso).
+- UI etapa 3: Supplier fixo no topo (não arrastável), colunas intermediárias com toggle ativar/desativar, PO fixo no final, lista "Disabled columns", aviso de colunas vazias, preview em árvore.
+
+### 2.4 Preview entre etapas 3 e 4
+- Etapa 4 (Destino) passa a exibir, no topo, o preview da estrutura de pastas (árvore + pasta raiz).
+- O modal "Confirm destination / Review folder structure" deixa de ser exibido ao iniciar o download (sem segunda confirmação).
+
+### 2.5 Proteção do input arquivado
+- Após a conclusão da run, o input arquivado (`input_source_{id}.{ext}`) recebe atributo somente leitura (chmod 444 / attrib +R).
+- No retry in-place: remover proteção → editar → reaplicar (em `persist_retry_files` / `_replace_po_in_file`).
+- Ao selecionar como input um arquivo que é snapshot de outra run, criar cópia de trabalho em `~/.contract_downloader/working/` (a run nova nunca edita o snapshot da anterior).
+
+### 2.6 Descrição da run
+- Coluna `description` em `sessions` (migração nos dois DBs).
+- `COUPA_RUN_DESCRIPTION` para o pipeline; `set_run_description()` para edição posterior.
+- UI: campo livre no header do modal de detalhes (ao lado do título da run) + coluna "Description" no histórico; input do histórico clicável (abre o snapshot arquivado).
+
+### 2.7 Travamento da New Run durante execução
+- `runInProgress`: botão de navegação New Run desabilitado, banner ativo, Start Over e limpar arquivo desabilitados; ao concluir, reabilita.
+
+### 2.8 Correções de inicialização/UX
+- Startup: carregar settings (com retry até `pywebview.api` disponível) antes de marcar como feito; aplicar idioma e font scale.
+- `updateAuthUI`: esconder `.auth-action` quando autenticado.
+- Janela: largura mínima maior (1080) e `min_size` maior; teste de geometria atualizado.
+
+## 3. Arquivos alterados
+
+| Arquivo | Mudança |
+|---|---|
+| `src/engine/input_schema.py` | novo: detecção/resolução de mapeamento |
+| `src/db/session_db.py` | coluna `description`, `update_session_description` |
+| `process_all_pos.py` | Supplier L1, mapeamento por env, descrição por env, filtro de colunas vazias |
+| `src/gui/api.py` | `get_input_columns`, `map_input_columns`, validação agrupada, `clean_invalid_chars`, import com mapeamento |
+| `src/gui/cli_supervisor.py` | `description`, `set_run_description`, proteção read-only, migração |
+| `src/main.py` | working copy de snapshots, descrição no start, geometria da janela |
+| `src/gui/web/index.html` | painéis 2/3/4, detalhes, histórico, banner |
+| `src/gui/web/app.js` | toda a lógica de UI acima |
+| `src/gui/web/style.css` | estilos novos |
+| `tests/*` | ajustes + novos testes |
+
+## 4. Critérios de aceite
+
+- 131+ testes existentes passam (com ajustes de expectativa de Supplier-first e geometria).
+- Fluxo completo: input padrão e input não padrão (com mapeamento) → validação agrupada → hierarquia com Supplier fixo → preview → destino → run.
+- Input arquivado fica read-only após a run; retry edita e reaplica proteção.
+- Descrição salva e exibida em detalhes e histórico.
+- Idioma salvo aplicado na abertura do app sem abrir Settings.

--- a/PR_PLANS/26-ux-revisao-mapeamento-colunas-relatorio-implementacao.md
+++ b/PR_PLANS/26-ux-revisao-mapeamento-colunas-relatorio-implementacao.md
@@ -1,0 +1,53 @@
+# Relatório de Implementação — Revisão UX + Mapeamento de Colunas
+
+**Data:** 2026-07-31
+**Design doc:** `PR_PLANS/26-ux-revisao-mapeamento-colunas-design-doc.md`
+
+## Entregue
+
+### 1. Correções de inicialização e janela
+- Janela maior: largura mínima 1080 (88% da tela), `min_size` (1000×680) — título e controles não ficam mais comprimidos.
+- Idioma salvo (pt-BR) é carregado **antes** da primeira renderização: `runStartupChecks` agora aguarda a ponte pywebview estar disponível antes de aplicar settings.
+- Botão de autenticação: quando autenticado, a ação redundante "Sign in/Entrar" é ocultada (um estado por vez).
+
+### 2. Fluxo New Run
+- **Start Over** movido para a etapa 5 (Review): só existe quando há estado para limpar, com confirmação explicando que o histórico é preservado e uma nova run será criada.
+- **New Run bloqueada durante execução ativa**: navegação desabilitada, banner traduzido, retorno automático para Active Run.
+
+### 3. Validação agrupada com correções por grupo
+- Erros agora são retornados em `groups` por categoria: `blank_rows`, `partial_rows`, `duplicate_pos`, `invalid_chars`, `unusual_format`, `missing_po_column`, `missing_supplier_column`.
+- Correções seguras por grupo: `remove_blank_rows`, `remove_duplicate_pos`, **`clean_invalid_chars`** (novo, CSV e XLSX, com backup).
+- Problemas sem correção automática (formato inválido): botão "Open file to fix" abre o arquivo no editor.
+
+### 4. Mapeamento de colunas (arquivos não padronizados)
+- Novo módulo `src/engine/input_schema.py` (detecção + resolução de mapeamento), compartilhado entre GUI e pipeline CLI (`COUPA_COLUMN_MAPPING`).
+- `get_input_columns` / `map_input_columns`: card "Map the file columns" na etapa de validação; mapeamento persistido em `~/.contract_downloader/column_mappings.json` por arquivo.
+- Arquivos sem `<|>` agora têm todas as colunas (exceto PO/Supplier) como candidatas a hierarquia; o usuário escolhe ativar/desativar.
+
+### 5. Hierarquia Supplier-first (fim a fim)
+- `_build_output_subdir` e `AppAPI.import_file` sempre usam **Supplier como Nível 1**; PO permanece no nível final.
+- UI etapa 3: Supplier fixo (não arrastável), PO fixo no final, níveis intermediários arrastáveis com toggle ×/+ (lista "Disabled columns"), colunas 100% vazias geram aviso e não criam pastas.
+- O pipeline respeita ordem explícita, inclusive vazia (`COUPA_HIERARCHY_ORDER` agora é enviado mesmo quando vazio).
+
+### 6. Preview entre etapas 3 e 4
+- A etapa 4 exibe a árvore de pastas (preview) antes do campo de destino.
+- O modal "Confirm destination" foi **removido** do início do download (sem segunda confirmação).
+
+### 7. Proteção dos inputs arquivados
+- Após a run, `input_source_{id}` recebe atributo somente leitura (chmod 444).
+- Retry explícito remove a proteção, edita e reaplica.
+- Selecionar um snapshot de outra run cria cópia de trabalho em `~/.contract_downloader/working/` — o snapshot original nunca é alterado incidentalmente.
+
+### 8. Descrição da run (auditoria)
+- Coluna `description` em `sessions` (migração nos dois bancos); `COUPA_RUN_DESCRIPTION` para o pipeline; `set_run_description` para edição posterior.
+- UI: campo livre no modal de detalhes (ao lado do título) + coluna "Description" no histórico; input do histórico clicável (abre o snapshot).
+
+## Validação
+
+- **156 testes passando** (eram 131; +25 novos cobrindo mapeamento, grupos de validação, `clean_invalid_chars`, supplier-first, descrição, proteção e working copy).
+- E2E Playwright (mock e real): jornada completa sem erros de página.
+- `git diff --check`, `node --check`, `py_compile` limpos.
+
+## Fora de escopo (mantidos para sprints futuras)
+
+- Terminal headless; velocidade total/ETA; links clicáveis no log; notificação de conclusão; enriquecimento via Coupa; SharePoint; IA; Power BI.


### PR DESCRIPTION
## Contexto
Correções priorizadas na reunião de revisão de 31/07 (Contract Downloader) + mapeamento de colunas para inputs não padronizados.

## Alterações
- Janela maior e idiom salvo aplicado na inicialização (sem abrir Settings).
- Start Over movido para a etapa final; New Run bloqueada durante execução ativa.
- Validação agrupada por tipo de erro com botões Fix por grupo (linhas vazias, POs duplicadas, caracteres inválidos) e "Open file to fix".
- Mapeamento de colunas: arquivos sem PO_NUMBER/SUPPLIER podem ser mapeados pela UI (persistido por arquivo, propagado ao pipeline via COUPA_COLUMN_MAPPING).
- Hierarquia Supplier-first fim a fim (Supplier nível 1 fixo, PO final fixo), toggles de colunas, colunas vazias ignoradas com aviso.
- Preview da estrutura entre etapas 3 e 4; modal de confirmação removido do início do download.
- Inputs arquivados protegidos (somente leitura) após a run; retry remove/re aplica; reuso de snapshot cria working copy.
- Campo de descrição da run (auditoria) salvo no banco, editável nos detalhes e visível no histórico; input do histórico clicável.

## Validação
- 156 testes aprovados (131 anteriores + 25 novos)
- E2E Playwright mock e real sem erros de página
- node --check, py_compile, git diff --check limpos

## Summary by Sourcery

Revise the Contract Downloader UX to lock the New Run journey during active downloads, add a Supplier-first hierarchy with folder previews, and introduce column mapping for non-standard inputs while preserving archived inputs as read-only audit snapshots and capturing run descriptions for history.

New Features:
- Allow users to map PO and Supplier columns for non-standard input files in the GUI, persisting mappings per file and propagating them to the CLI pipeline via environment configuration.
- Introduce a Supplier-first folder hierarchy model with fixed first (Supplier) and last (PO) levels, optional intermediate levels with enable/disable toggles, and a textual preview of the resulting directory tree before runs start.
- Add a free-form run description field that is stored with sessions, editable from the run details modal, and shown in the run history table, with clickable links to preserved input snapshots.

Bug Fixes:
- Ensure saved language and font settings are applied on first render by waiting for the settings API on startup, and hide redundant authentication actions when already signed in.
- Prevent starting a new preparation while a run is active by disabling the New Run journey, gating Start Over during active runs, and showing an in-context banner redirecting users to the active run.
- Protect archived input snapshots as read-only after runs complete and temporarily lift protection only during explicit retry flows to avoid accidental in-place edits.

Enhancements:
- Group input validation issues by category with per-group Fix actions, including safe cleanup of invalid PO characters, and surface column-level hierarchy warnings for empty columns.
- Expand and slightly resize the main window to better accommodate titles, controls, and localized copy, and relocate the Start Over action to the final review step with clearer confirmation text.
- Unify column schema handling between GUI and CLI through a shared input schema module, including detection and resolution of required PO/Supplier columns and environment-driven mappings.

Tests:
- Add unit and end-to-end tests covering grouped validation behavior, column mapping and propagation to the pipeline, Supplier-first hierarchy output, run description persistence, archived input protection semantics, working copy behavior, and updated window geometry constraints.